### PR TITLE
fix: dependency cleanup, pandas 3.0 compat, and Windows pool fix

### DIFF
--- a/pandas_ta_classic/core.py
+++ b/pandas_ta_classic/core.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from copy import copy
 from dataclasses import dataclass, field
 from multiprocessing import cpu_count, Pool
 from pathlib import Path
@@ -772,8 +773,7 @@ class AnalysisIndicators(BasePandasObject):
             # pickles self._df (which grows as indicators are appended),
             # causing pandas BlockManager integrity errors in workers and
             # pool deadlocks.
-            slim = self.__class__.__new__(self.__class__)
-            slim.__dict__.update(self.__dict__)
+            slim = copy(self)
             slim._df = self._df[self._df.columns[:initial_column_count]].copy()
 
             pool = Pool(self.cores)
@@ -831,12 +831,16 @@ class AnalysisIndicators(BasePandasObject):
                             )  # Speed over Order
                 if results is None:
                     print(f"[X] ta.strategy('{name}') has no results.")
+                    pool.terminate()
                     return
 
                 # Consume the lazy iterator while the pool is still alive.
                 [self._post_process(r, **kwargs) for r in results]
-            finally:
+                pool.close()
+            except Exception:
                 pool.terminate()
+                raise
+            finally:
                 pool.join()
 
             del slim

--- a/pandas_ta_classic/core.py
+++ b/pandas_ta_classic/core.py
@@ -766,7 +766,18 @@ class AnalysisIndicators(BasePandasObject):
 
         if use_multiprocessing:
             _total_ta = len(ta)
-            with Pool(self.cores) as pool:
+
+            # Create a lightweight copy of self that contains only the
+            # original OHLCV columns.  Without this, each imap() call
+            # pickles self._df (which grows as indicators are appended),
+            # causing pandas BlockManager integrity errors in workers and
+            # pool deadlocks.
+            slim = self.__class__.__new__(self.__class__)
+            slim.__dict__.update(self.__dict__)
+            slim._df = self._df[self._df.columns[:initial_column_count]].copy()
+
+            pool = Pool(self.cores)
+            try:
                 # Some magic to optimize chunksize for speed based on total ta indicators
                 _chunksize = (
                     mp_chunksize - 1
@@ -794,38 +805,42 @@ class AnalysisIndicators(BasePandasObject):
                         for ind in ta
                     ]
                     # Custom multiprocessing pool. Must be ordered for Chained Strategies
-                    # May fix this to cpus if Chaining/Composition if it remains
-                    results = pool.imap(self._mp_worker, custom_ta, _chunksize)
+                    results = pool.imap(slim._mp_worker, custom_ta, _chunksize)
                 else:
                     default_ta: list = [(ind, tuple(), kwargs) for ind in ta]
                     # All and Categorical multiprocessing pool.
                     if all_ordered:
                         if Imports["tqdm"]:
                             results = tqdm(
-                                pool.imap(self._mp_worker, default_ta, _chunksize)
+                                pool.imap(slim._mp_worker, default_ta, _chunksize)
                             )  # Order over Speed
                         else:
                             results = pool.imap(
-                                self._mp_worker, default_ta, _chunksize
+                                slim._mp_worker, default_ta, _chunksize
                             )  # Order over Speed
                     else:
                         if Imports["tqdm"]:
                             results = tqdm(
                                 pool.imap_unordered(
-                                    self._mp_worker, default_ta, _chunksize
+                                    slim._mp_worker, default_ta, _chunksize
                                 )
                             )  # Speed over Order
                         else:
                             results = pool.imap_unordered(
-                                self._mp_worker, default_ta, _chunksize
+                                slim._mp_worker, default_ta, _chunksize
                             )  # Speed over Order
                 if results is None:
                     print(f"[X] ta.strategy('{name}') has no results.")
                     return
 
-                pool.close()
+                # Consume the lazy iterator while the pool is still alive.
+                [self._post_process(r, **kwargs) for r in results]
+            finally:
+                pool.terminate()
                 pool.join()
-                self._last_run = get_time(self.exchange, to_string=True)
+
+            del slim
+            self._last_run = get_time(self.exchange, to_string=True)
 
         else:
             # Without multiprocessing:
@@ -864,9 +879,6 @@ class AnalysisIndicators(BasePandasObject):
                     for ind in ta:
                         getattr(self, ind)(*tuple(), **kwargs)
                 self._last_run = get_time(self.exchange, to_string=True)
-
-        # Apply prefixes/suffixes and appends indicator results to the  DataFrame
-        [self._post_process(r, **kwargs) for r in results]
 
         if verbose:
             print(f"[i] Total indicators: {len(ta)}")

--- a/pandas_ta_classic/momentum/trix.py
+++ b/pandas_ta_classic/momentum/trix.py
@@ -31,7 +31,7 @@ def trix(
     ema1 = ema(close=close, length=length, **kwargs)
     ema2 = ema(close=ema1, length=length, **kwargs)
     ema3 = ema(close=ema2, length=length, **kwargs)
-    trix = scalar * ema3.pct_change(drift)
+    trix = scalar * (ema3 / ema3.shift(drift) - 1)
 
     trix_signal = trix.rolling(signal).mean()
 

--- a/pandas_ta_classic/performance/percent_return.py
+++ b/pandas_ta_classic/performance/percent_return.py
@@ -26,7 +26,7 @@ def percent_return(
     if cumulative:
         pct_return = (close / close.iloc[0]) - 1
     else:
-        pct_return = close.pct_change(length)  # (close / close.shift(length)) - 1
+        pct_return = close / close.shift(length) - 1
 
     # Offset
     if offset != 0:

--- a/pandas_ta_classic/performance/percent_return.py
+++ b/pandas_ta_classic/performance/percent_return.py
@@ -26,7 +26,7 @@ def percent_return(
     if cumulative:
         pct_return = (close / close.iloc[0]) - 1
     else:
-        pct_return = close / close.shift(length) - 1
+        pct_return = (close / close.shift(length)) - 1
 
     # Offset
     if offset != 0:
@@ -64,7 +64,7 @@ Sources:
 Calculation:
     Default Inputs:
         length=1, cumulative=False
-    PCTRET = close.pct_change(length)
+    PCTRET = close / close.shift(length) - 1
     CUMPCTRET = PCTRET.cumsum() if cumulative
 
 Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,16 +39,13 @@ requires-python = ">=3.9"  # Minimum Python version - dynamically updated by CI/
 dependencies = [
     "numpy>=2.0.0",
     "pandas>=2.0.0",
-    "python-dateutil>=2.8.1",
-    "pytz>=2021.1",
-    "six>=1.16.0"
 ]
 
 [project.optional-dependencies]
 # Core optional runtime dependencies
 optional = [
     "scipy",
-    "sklearn", 
+    "scikit-learn",
     "statsmodels",
     "stochastic",
     "talib",


### PR DESCRIPTION
## Summary
- Remove unused transitive dependencies and fix scikit-learn package name
- Replace deprecated `pct_change` for pandas 3.0 compatibility
- Prevent zombie worker processes and pool deadlocks on Windows

## Test plan
- [x] `pytest` passes on Python 3.9–3.13
- [x] No import errors after dependency cleanup
- [x] Windows multiprocessing no longer hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)