### PR TITLE
fix: resolve initialization and edge-case bugs across 11 indicators

### DIFF
--- a/pandas_ta_classic/momentum/stoch.py
+++ b/pandas_ta_classic/momentum/stoch.py
@@ -39,8 +39,8 @@ def stoch(
     stoch = 100 * (close - lowest_low)
     stoch /= non_zero_range(highest_high, lowest_low)
 
-    stoch_k = ma(mamode, stoch.loc[stoch.first_valid_index() :,], length=smooth_k)
-    stoch_d = ma(mamode, stoch_k.loc[stoch_k.first_valid_index() :,], length=d)
+    stoch_k = ma(mamode, stoch, length=smooth_k)
+    stoch_d = ma(mamode, stoch_k, length=d)
 
     # Offset
     if offset != 0:

--- a/pandas_ta_classic/overlap/alma.py
+++ b/pandas_ta_classic/overlap/alma.py
@@ -40,17 +40,16 @@ def alma(
         wtd[i] = npExp(-1 * ((i - m) * (i - m)) / (2 * s * s))
 
     # Calculate Result
-    result = [npNaN for _ in range(0, length - 1)] + [0]
-    for i in range(length, close.size):
+    result = [npNaN for _ in range(0, length - 1)]
+    for i in range(length - 1, close.size):
         window_sum = 0
         cum_sum = 0
         for j in range(0, length):
-            # wtd = math.exp(-1 * ((j - m) * (j - m)) / (2 * s * s))        # moved to pre-calc for efficiency
             window_sum = window_sum + wtd[j] * close.iloc[i - j]
             cum_sum = cum_sum + wtd[j]
 
         almean = window_sum / cum_sum
-        result.append(npNaN) if i == length else result.append(almean)
+        result.append(almean)
 
     alma = Series(result, index=close.index)
 

--- a/pandas_ta_classic/overlap/ichimoku.py
+++ b/pandas_ta_classic/overlap/ichimoku.py
@@ -96,7 +96,7 @@ def ichimoku(
     chikou_span.name = f"ICS_{kijun}"
 
     chikou_span.category = kijun_sen.category = tenkan_sen.category = "trend"
-    span_b.category = span_a.category = chikou_span
+    span_b.category = span_a.category = "trend"
 
     # Prepare Ichimoku DataFrame
     data = {

--- a/pandas_ta_classic/overlap/kama.py
+++ b/pandas_ta_classic/overlap/kama.py
@@ -44,7 +44,7 @@ def kama(
     sc = x * x
 
     m = close.size
-    result = [npNaN for _ in range(0, length - 1)] + [0]
+    result = [npNaN for _ in range(0, length - 1)] + [close.iloc[length - 1]]
     for i in range(length, m):
         result.append(sc.iloc[i] * close.iloc[i] + (1 - sc.iloc[i]) * result[i - 1])
 

--- a/pandas_ta_classic/overlap/rma.py
+++ b/pandas_ta_classic/overlap/rma.py
@@ -21,8 +21,14 @@ def rma(
     if close is None:
         return None
 
-    # Calculate Result
-    rma = close.ewm(alpha=alpha, min_periods=length).mean()
+    # Calculate Result — SMA-seeded Wilder smoothing (matches TA-Lib)
+    import numpy as np
+
+    close = close.copy()
+    sma_nth = close[0:length].mean()
+    close[: length - 1] = np.nan
+    close.iloc[length - 1] = sma_nth
+    rma = close.ewm(alpha=alpha, adjust=False).mean()
 
     # Offset
     if offset != 0:
@@ -56,9 +62,11 @@ Sources:
 Calculation:
     Default Inputs:
         length=10
-    EMA = Exponential Moving Average
     alpha = 1 / length
-    RMA = EMA(close, alpha=alpha)
+    SMA_nth = SMA(close, length)
+    close[:length - 1] = NaN
+    close[length - 1] = SMA_nth
+    RMA = EWM(close, alpha=alpha, adjust=False)
 
 Args:
     close (pd.Series): Series of 'close's

--- a/pandas_ta_classic/overlap/rma.py
+++ b/pandas_ta_classic/overlap/rma.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Wilder's Moving Average (RMA)
 from typing import Any, Optional
+import numpy as np
 from pandas import Series
 from pandas_ta_classic.utils import get_offset, verify_series
 
@@ -22,11 +23,9 @@ def rma(
         return None
 
     # Calculate Result — SMA-seeded Wilder smoothing (matches TA-Lib)
-    import numpy as np
-
     close = close.copy()
-    sma_nth = close[0:length].mean()
-    close[: length - 1] = np.nan
+    sma_nth = close.iloc[0:length].mean()
+    close.iloc[: length - 1] = np.nan
     close.iloc[length - 1] = sma_nth
     rma = close.ewm(alpha=alpha, adjust=False).mean()
 

--- a/pandas_ta_classic/overlap/ssf.py
+++ b/pandas_ta_classic/overlap/ssf.py
@@ -41,7 +41,7 @@ def ssf(
         c2 = c0 + b0  # e^(-2x) + 2e^(-x)*cos(3^(.5) * x)
         c1 = 1 - c2 - c3 - c4
 
-        for i in range(0, m):
+        for i in range(3, m):
             ssf.iloc[i] = (
                 c1 * close.iloc[i]
                 + c2 * ssf.iloc[i - 1]
@@ -56,7 +56,7 @@ def ssf(
         b1 = 2 * a0 * npCos(x)  # 2e^(-x)*cos(x)
         c1 = 1 - a1 - b1  # e^(-2x) - 2e^(-x)*cos(x) + 1
 
-        for i in range(0, m):
+        for i in range(2, m):
             ssf.iloc[i] = (
                 c1 * close.iloc[i] + b1 * ssf.iloc[i - 1] + a1 * ssf.iloc[i - 2]
             )

--- a/pandas_ta_classic/overlap/trima.py
+++ b/pandas_ta_classic/overlap/trima.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Triangular Moving Average (TRIMA)
+from math import ceil, floor
 from typing import Any, Optional
 from pandas import Series
 from .sma import sma
@@ -30,9 +31,10 @@ def trima(
 
         trima = TRIMA(close, length)
     else:
-        half_length = round(0.5 * (length + 1))
-        sma1 = sma(close, length=half_length)
-        trima = sma(sma1, length=half_length)
+        first_window = ceil(length / 2)
+        second_window = floor(length / 2) + 1
+        sma1 = sma(close, length=first_window)
+        trima = sma(sma1, length=second_window)
 
     # Offset
     if offset != 0:
@@ -73,9 +75,10 @@ Calculation:
     Default Inputs:
         length=10
     SMA = Simple Moving Average
-    half_length = round(0.5 * (length + 1))
-    SMA1 = SMA(close, half_length)
-    TRIMA = SMA(SMA1, half_length)
+    first_window = ceil(length / 2)
+    second_window = floor(length / 2) + 1
+    SMA1 = SMA(close, first_window)
+    TRIMA = SMA(SMA1, second_window)
 
 Args:
     close (pd.Series): Series of 'close's

--- a/pandas_ta_classic/overlap/vidya.py
+++ b/pandas_ta_classic/overlap/vidya.py
@@ -43,12 +43,15 @@ def vidya(
     m = close.size
     alpha = 2 / (length + 1)
     abs_cmo = _cmo(close, length, drift).abs()
-    vidya = Series(0.0, index=close.index)
+    vidya_arr = np.full(m, npNaN)
+    vidya_arr[length - 1] = close.iloc[:length].mean()  # SMA seed
+    cmo_arr = abs_cmo.to_numpy()
+    c_arr = close.to_numpy()
     for i in range(length, m):
-        vidya.iloc[i] = alpha * abs_cmo.iloc[i] * close.iloc[i] + vidya.iloc[i - 1] * (
-            1 - alpha * abs_cmo.iloc[i]
+        vidya_arr[i] = alpha * cmo_arr[i] * c_arr[i] + vidya_arr[i - 1] * (
+            1 - alpha * cmo_arr[i]
         )
-    vidya.replace({0: npNaN}, inplace=True)
+    vidya = Series(vidya_arr, index=close.index)
 
     # Offset
     if offset != 0:

--- a/pandas_ta_classic/overlap/zlma.py
+++ b/pandas_ta_classic/overlap/zlma.py
@@ -2,7 +2,18 @@
 # Zero Lag Moving Average (ZLMA)
 from typing import Any, Optional
 from pandas import Series
-from . import dema, ema, hma, linreg, rma, sma, swma, t3, tema, trima, vidya, wma
+from .dema import dema
+from .ema import ema
+from .hma import hma
+from .linreg import linreg
+from .rma import rma
+from .sma import sma
+from .swma import swma
+from .t3 import t3
+from .tema import tema
+from .trima import trima
+from .vidya import vidya
+from .wma import wma
 from pandas_ta_classic.utils import get_offset, verify_series
 
 

--- a/pandas_ta_classic/trend/tsignals.py
+++ b/pandas_ta_classic/trend/tsignals.py
@@ -17,6 +17,9 @@ def tsignals(
     """Indicator: Trend Signals"""
     # Validate Arguments
     trend = verify_series(trend)
+    if trend is None:
+        return None
+
     asbool = bool(asbool) if isinstance(asbool, bool) else False
     trend_reset = (
         int(trend_reset) if trend_reset and isinstance(trend_reset, int) else 0
@@ -29,7 +32,7 @@ def tsignals(
     offset = get_offset(offset)
 
     # Calculate Result
-    trends = trend.astype(int)
+    trends = trend.fillna(0).astype(int)
     trades = trends.diff(drift).shift(trade_offset).fillna(0).astype(int)
     entries = (trades > 0).astype(int)
     exits = (trades < 0).abs().astype(int)

--- a/pandas_ta_classic/volatility/bbands.py
+++ b/pandas_ta_classic/volatility/bbands.py
@@ -20,7 +20,7 @@ def bbands(
 ) -> Optional[DataFrame]:
     """Indicator: Bollinger Bands (BBANDS)"""
     # Validate arguments
-    length = int(length) if length and length > 0 else 5
+    length = int(length) if length and length > 1 else 5
     std = float(std) if std and std > 0 else 2.0
     mamode = mamode if isinstance(mamode, str) else "sma"
     ddof = int(ddof) if ddof >= 0 and ddof < length else 1


### PR DESCRIPTION
## Summary
- **ssf**: fix data leak from numpy negative indexing
- **zlma**: fix broken mamode dispatch
- **bbands**: add length=1 guard
- **tsignals**: fix NaN crash on empty input
- **stoch**: fix output-length truncation
- **ichimoku**: assign string category to span_a/span_b
- **rma**: fix initialization bug
- **kama**: fix initialization bug
- **trima**: fix rounding bug
- **alma**: fix initialization bug
- **vidya**: fix initialization bug

## Test plan
- [x] `pytest` passes on Python 3.9–3.13
- [x] Each fixed indicator produces correct output for edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)