### PR TITLE
fix: align 8 indicators with TA-Lib reference implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## **[Unreleased]**
 
+### Changed
+* **`linreg` breaking default change**: The `degrees` kwarg now defaults to `True` (was `False`) to match TA-Lib's convention. Any caller using `linreg(close, angle=True)` without explicitly passing `degrees=False` will now receive degrees instead of radians.
+* **`stdev`/`variance` breaking default change**: The `ddof` parameter now defaults to `0` (population std/variance, was `1` sample std/variance) to match TA-Lib. Callers relying on the default sample variance must now pass `ddof=1` explicitly.
+
 ### Added
 * **9 New Technical Indicators**: Added high-demand indicators from Issue #29 analysis:
   - **LRSI** (Laguerre Relative Strength Index) - Momentum indicator with reduced lag using gamma parameter

--- a/pandas_ta_classic/candles/cdl_doji.py
+++ b/pandas_ta_classic/candles/cdl_doji.py
@@ -43,7 +43,11 @@ def cdl_doji(
     doji = body <= 0.01 * factor * hl_range_avg
 
     if naive:
-        doji.iloc[:length] = body <= 0.01 * factor * hl_range
+        # sma(...).shift(1) produces NaN at indices 0..length (length+1 NaN),
+        # so the naive fallback must cover that full range. Use .to_numpy() on
+        # the RHS so pandas doesn't complain about mismatched slice lengths.
+        naive_vals = (body <= 0.01 * factor * hl_range).to_numpy()
+        doji.iloc[:length + 1] = naive_vals[:length + 1]
     if asint:
         doji = scalar * doji.astype(int)
 

--- a/pandas_ta_classic/candles/cdl_doji.py
+++ b/pandas_ta_classic/candles/cdl_doji.py
@@ -35,13 +35,15 @@ def cdl_doji(
         return None
 
     # Calculate Result
+    # TA-Lib averages the HL range of the *previous* ``length`` bars
+    # (excluding the current bar), so shift the SMA by 1.
     body = real_body(open_, close).abs()
     hl_range = high_low_range(high, low).abs()
-    hl_range_avg = sma(hl_range, length)
-    doji = body < 0.01 * factor * hl_range_avg
+    hl_range_avg = sma(hl_range, length).shift(1)
+    doji = body <= 0.01 * factor * hl_range_avg
 
     if naive:
-        doji.iloc[:length] = body < 0.01 * factor * hl_range
+        doji.iloc[:length] = body <= 0.01 * factor * hl_range
     if asint:
         doji = scalar * doji.astype(int)
 

--- a/pandas_ta_classic/candles/cdl_doji.py
+++ b/pandas_ta_classic/candles/cdl_doji.py
@@ -47,7 +47,7 @@ def cdl_doji(
         # so the naive fallback must cover that full range. Use .to_numpy() on
         # the RHS so pandas doesn't complain about mismatched slice lengths.
         naive_vals = (body <= 0.01 * factor * hl_range).to_numpy()
-        doji.iloc[:length + 1] = naive_vals[:length + 1]
+        doji.iloc[: length + 1] = naive_vals[: length + 1]
     if asint:
         doji = scalar * doji.astype(int)
 

--- a/pandas_ta_classic/momentum/cmo.py
+++ b/pandas_ta_classic/momentum/cmo.py
@@ -35,15 +35,12 @@ def cmo(
         cmo = CMO(close, length)
     else:
         mom = close.diff(drift)
-        positive = mom.copy().clip(lower=0)
-        negative = mom.copy().clip(upper=0).abs()
+        positive = mom.clip(lower=0)
+        negative = mom.clip(upper=0).abs()
 
-        if mode_tal:
-            pos_ = rma(positive, length)
-            neg_ = rma(negative, length)
-        else:
-            pos_ = positive.rolling(length).sum()
-            neg_ = negative.rolling(length).sum()
+        # Use RMA (Wilder smoothing) to match TA-Lib's CMO algorithm.
+        pos_ = rma(positive, length)
+        neg_ = rma(negative, length)
 
         cmo = scalar * (pos_ - neg_) / (pos_ + neg_)
 

--- a/pandas_ta_classic/momentum/dm.py
+++ b/pandas_ta_classic/momentum/dm.py
@@ -45,10 +45,15 @@ def dm(
         pos_ = pos_.apply(zero).fillna(0)
         neg_ = neg_.apply(zero).fillna(0)
 
-        # TA-Lib outputs the Wilder-smoothed *sum* (not average), so
-        # we multiply the RMA (average) by ``length`` to match.
-        pos = ma(mamode, pos_, length=length) * length
-        neg = ma(mamode, neg_, length=length) * length
+        # TA-Lib outputs the Wilder-smoothed *sum* (not average) when using
+        # RMA (Wilder), so multiply by ``length`` to match. Other MA modes
+        # are returned as-is since the scaling only holds for RMA.
+        if mamode == "rma":
+            pos = ma(mamode, pos_, length=length) * length
+            neg = ma(mamode, neg_, length=length) * length
+        else:
+            pos = ma(mamode, pos_, length=length)
+            neg = ma(mamode, neg_, length=length)
 
     # Offset
     if offset != 0:
@@ -92,9 +97,14 @@ Calculation:
         pos_ = pos_.apply(zero)
         neg_ = neg_.apply(zero)
 
-        # Not the same values as TA Lib's -+DM
-        pos = ma(mamode, pos_, length=length)
-        neg = ma(mamode, neg_, length=length)
+        # For RMA (default), multiply by length to get the Wilder-smoothed sum
+        # matching TA-Lib. Other MA modes are returned as-is.
+        if mamode == "rma":
+            pos = ma(mamode, pos_, length=length) * length
+            neg = ma(mamode, neg_, length=length) * length
+        else:
+            pos = ma(mamode, pos_, length=length)
+            neg = ma(mamode, neg_, length=length)
 
 Args:
     high (pd.Series): Series of 'high's

--- a/pandas_ta_classic/momentum/dm.py
+++ b/pandas_ta_classic/momentum/dm.py
@@ -42,12 +42,13 @@ def dm(
         pos_ = ((up > dn) & (up > 0)) * up
         neg_ = ((dn > up) & (dn > 0)) * dn
 
-        pos_ = pos_.apply(zero)
-        neg_ = neg_.apply(zero)
+        pos_ = pos_.apply(zero).fillna(0)
+        neg_ = neg_.apply(zero).fillna(0)
 
-        # Not the same values as TA Lib's -+DM (Good First Issue)
-        pos = ma(mamode, pos_, length=length)
-        neg = ma(mamode, neg_, length=length)
+        # TA-Lib outputs the Wilder-smoothed *sum* (not average), so
+        # we multiply the RMA (average) by ``length`` to match.
+        pos = ma(mamode, pos_, length=length) * length
+        neg = ma(mamode, neg_, length=length) * length
 
     # Offset
     if offset != 0:

--- a/pandas_ta_classic/momentum/macd.py
+++ b/pandas_ta_classic/momentum/macd.py
@@ -38,11 +38,31 @@ def macd(
 
         macd, signalma, histogram = MACD(close, fast, slow, signal)
     else:
-        fastma = ema(close, length=fast)
-        slowma = ema(close, length=slow)
+        import numpy as np
 
-        macd = fastma - slowma
-        signalma = ema(close=macd.loc[macd.first_valid_index() :,], length=signal)
+        def _ema_aligned(arr, m, period, seed_end):
+            """EMA with SMA seed at a specific index, matching TA-Lib."""
+            result = np.full(m, np.nan)
+            k = 2.0 / (period + 1)
+            start = seed_end - period + 1
+            if start < 0 or seed_end >= m:
+                return result
+            result[seed_end] = arr[start : seed_end + 1].mean()
+            for i in range(seed_end + 1, m):
+                result[i] = k * arr[i] + (1 - k) * result[i - 1]
+            return result
+
+        c_arr = close.to_numpy(dtype=float)
+        m = c_arr.shape[0]
+        slow_start = slow - 1
+        slow_ema = _ema_aligned(c_arr, m, slow, slow_start)
+        fast_ema = _ema_aligned(c_arr, m, fast, slow_start)
+        macd_arr = fast_ema - slow_ema
+        sig_start = slow_start + signal - 1
+        sig_ema = _ema_aligned(macd_arr, m, signal, sig_start)
+
+        macd = Series(macd_arr, index=close.index)
+        signalma = Series(sig_ema, index=close.index)
         histogram = macd - signalma
 
     if as_mode:

--- a/pandas_ta_classic/momentum/macd.py
+++ b/pandas_ta_classic/momentum/macd.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Moving Average Convergence Divergence (MACD)
 from typing import Any, Optional
+import numpy as np
 from pandas import concat, DataFrame, Series
 from pandas_ta_classic import Imports
 from pandas_ta_classic.overlap.ema import ema
@@ -38,8 +39,6 @@ def macd(
 
         macd, signalma, histogram = MACD(close, fast, slow, signal)
     else:
-        import numpy as np
-
         def _ema_aligned(arr, m, period, seed_end):
             """EMA with SMA seed at a specific index, matching TA-Lib."""
             result = np.full(m, np.nan)
@@ -54,9 +53,13 @@ def macd(
 
         c_arr = close.to_numpy(dtype=float)
         m = c_arr.shape[0]
+        # TA-Lib seeds the fast EMA at its own lookback (fast-1) and the slow
+        # EMA at slow-1; by slow-1 the fast EMA has already been running for
+        # (slow - fast) additional bars, not reseeded with a fresh SMA.
+        fast_start = fast - 1
         slow_start = slow - 1
+        fast_ema = _ema_aligned(c_arr, m, fast, fast_start)
         slow_ema = _ema_aligned(c_arr, m, slow, slow_start)
-        fast_ema = _ema_aligned(c_arr, m, fast, slow_start)
         macd_arr = fast_ema - slow_ema
         sig_start = slow_start + signal - 1
         sig_ema = _ema_aligned(macd_arr, m, signal, sig_start)

--- a/pandas_ta_classic/momentum/macd.py
+++ b/pandas_ta_classic/momentum/macd.py
@@ -39,6 +39,7 @@ def macd(
 
         macd, signalma, histogram = MACD(close, fast, slow, signal)
     else:
+
         def _ema_aligned(arr, m, period, seed_end):
             """EMA with SMA seed at a specific index, matching TA-Lib."""
             result = np.full(m, np.nan)

--- a/pandas_ta_classic/overlap/linreg.py
+++ b/pandas_ta_classic/overlap/linreg.py
@@ -5,7 +5,6 @@ import numpy as np
 from numpy import array as npArray
 from numpy import arctan as npAtan
 from numpy import pi as npPi
-from numpy.version import version as npVersion
 from pandas import Series
 
 npNaN = np.nan
@@ -25,7 +24,7 @@ def linreg(
     offset = get_offset(offset)
     angle = kwargs.pop("angle", False)
     intercept = kwargs.pop("intercept", False)
-    degrees = kwargs.pop("degrees", False)
+    degrees = kwargs.pop("degrees", True)
     r = kwargs.pop("r", False)
     slope = kwargs.pop("slope", False)
     tsf = kwargs.pop("tsf", False)
@@ -33,55 +32,44 @@ def linreg(
     if close is None:
         return None
 
-    # Calculate Result
-    x = range(1, length + 1)  # [1, 2, ..., n] from 1 to n keeps Sum(xy) low
-    x_sum = 0.5 * length * (length + 1)
-    x2_sum = x_sum * (2 * length + 1) / 3
+    # Calculate Result — fully vectorised OLS over all windows at once.
+    # x = [0, 1, ..., L-1] matches TA-Lib convention; precompute scalar sums.
+    x_arr = np.arange(length, dtype=float)
+    x_sum = 0.5 * length * (length - 1)
+    x2_sum = length * (length - 1) * (2 * length - 1) / 6
     divisor = length * x2_sum - x_sum * x_sum
 
-    def linear_regression(series: Any) -> Any:
-        y_sum = series.sum()
-        xy_sum = (x * series).sum()
+    from numpy.lib.stride_tricks import sliding_window_view
 
-        m = (length * xy_sum - x_sum * y_sum) / divisor
-        if slope:
-            return m
-        b = (y_sum * x2_sum - x_sum * xy_sum) / divisor
+    windows = sliding_window_view(npArray(close, dtype=float), length)  # (n-L+1, L)
+    y_sums = windows.sum(axis=1)
+    xy_sums = (windows * x_arr).sum(axis=1)
+    m_slopes = (length * xy_sums - x_sum * y_sums) / divisor
+
+    if slope:
+        linreg_ = m_slopes
+    else:
+        bs = (y_sums * x2_sum - x_sum * xy_sums) / divisor
         if intercept:
-            return b
-
-        if angle:
-            theta = npAtan(m)
+            linreg_ = bs
+        elif angle:
+            theta = npAtan(m_slopes)
             if degrees:
                 theta *= 180 / npPi
-            return theta
+            linreg_ = theta
+        elif r:
+            y2_sums = (windows * windows).sum(axis=1)
+            rn = length * xy_sums - x_sum * y_sums
+            rd = (divisor * (length * y2_sums - y_sums**2)) ** 0.5
+            linreg_ = rn / rd
+        elif tsf:
+            linreg_ = m_slopes * length + bs
+        else:
+            linreg_ = m_slopes * (length - 1) + bs
 
-        if r:
-            y2_sum = (series * series).sum()
-            rn = length * xy_sum - x_sum * y_sum
-            rd = (divisor * (length * y2_sum - y_sum * y_sum)) ** 0.5
-            return rn / rd
-
-        return m * length + b if tsf else m * (length - 1) + b
-
-    def rolling_window(array: Any, length: int) -> Any:
-        """https://github.com/twopirllc/pandas-ta/issues/285"""
-        strides = array.strides + (array.strides[-1],)
-        shape = array.shape[:-1] + (array.shape[-1] - length + 1, length)
-        return as_strided(array, shape=shape, strides=strides)
-
-    if npVersion >= "1.20.0":
-        from numpy.lib.stride_tricks import sliding_window_view
-
-        linreg_ = [
-            linear_regression(_) for _ in sliding_window_view(npArray(close), length)
-        ]
-    else:
-        from numpy.lib.stride_tricks import as_strided
-
-        linreg_ = [linear_regression(_) for _ in rolling_window(npArray(close), length)]
-
-    linreg = Series([npNaN] * (length - 1) + linreg_, index=close.index)
+    linreg = Series(
+        np.concatenate([[npNaN] * (length - 1), linreg_]), index=close.index
+    )
 
     # Offset
     if offset != 0:
@@ -91,28 +79,23 @@ def linreg(
     if "fillna" in kwargs:
         linreg.fillna(kwargs["fillna"], inplace=True)
     if "fill_method" in kwargs:
-        if "fill_method" in kwargs:
-
-            if kwargs["fill_method"] == "ffill":
-
-                linreg.ffill(inplace=True)
-
-            elif kwargs["fill_method"] == "bfill":
-
-                linreg.bfill(inplace=True)
+        if kwargs["fill_method"] == "ffill":
+            linreg.ffill(inplace=True)
+        elif kwargs["fill_method"] == "bfill":
+            linreg.bfill(inplace=True)
 
     # Name and Categorize it
-    linreg.name = f"LR"
+    name = "LR"
     if slope:
-        linreg.name += "m"
+        name += "m"
     if intercept:
-        linreg.name += "b"
+        name += "b"
     if angle:
-        linreg.name += "a"
+        name += "a"
     if r:
-        linreg.name += "r"
-
-    linreg.name += f"_{length}"
+        name += "r"
+    name += f"_{length}"
+    linreg.name = name
     linreg.category = "overlap"
 
     return linreg
@@ -129,9 +112,9 @@ Source: TA Lib
 Calculation:
     Default Inputs:
         length=14
-    x = [1, 2, ..., n]
-    x_sum = 0.5 * length * (length + 1)
-    x2_sum = length * (length + 1) * (2 * length + 1) / 6
+    x = [0, 1, ..., n-1]  (matches TA-Lib convention)
+    x_sum = 0.5 * length * (length - 1)
+    x2_sum = length * (length - 1) * (2 * length - 1) / 6
     divisor = length * x2_sum - x_sum * x_sum
 
     lr(series):
@@ -151,10 +134,10 @@ Args:
     offset (int): How many periods to offset the result.  Default: 0
 
 Kwargs:
-    angle (bool, optional): If True, returns the angle of the slope in radians.
+    angle (bool, optional): If True, returns the angle of the slope.
         Default: False.
-    degrees (bool, optional): If True, returns the angle of the slope in
-        degrees. Default: False.
+    degrees (bool, optional): If True, returns the angle in degrees;
+        if False, in radians. Default: True (matches TA-Lib convention).
     intercept (bool, optional): If True, returns the angle of the slope in
         radians. Default: False.
     r (bool, optional): If True, returns it's correlation 'r'. Default: False.

--- a/pandas_ta_classic/statistics/stdev.py
+++ b/pandas_ta_classic/statistics/stdev.py
@@ -75,7 +75,7 @@ Args:
     length (int): It's period. Default: 30
     ddof (int): Delta Degrees of Freedom.
                 The divisor used in calculations is N - ddof,
-                where N represents the number of elements. Default: 1
+                where N represents the number of elements. Default: 0
     talib (bool): If TA Lib is installed and talib is True, Returns the TA Lib
         version. Default: True
     offset (int): How many periods to offset the result. Default: 0

--- a/pandas_ta_classic/statistics/stdev.py
+++ b/pandas_ta_classic/statistics/stdev.py
@@ -19,7 +19,7 @@ def stdev(
     """Indicator: Standard Deviation"""
     # Validate Arguments
     length = int(length) if length and length > 0 else 30
-    ddof = int(ddof) if isinstance(ddof, int) and ddof >= 0 and ddof < length else 1
+    ddof = int(ddof) if isinstance(ddof, int) and ddof >= 0 and ddof < length else 0
     close = verify_series(close, length)
     offset = get_offset(offset)
     mode_tal = bool(talib) if isinstance(talib, bool) else True

--- a/pandas_ta_classic/statistics/variance.py
+++ b/pandas_ta_classic/statistics/variance.py
@@ -17,7 +17,7 @@ def variance(
     """Indicator: Variance"""
     # Validate Arguments
     length = int(length) if length and length > 1 else 30
-    ddof = int(ddof) if isinstance(ddof, int) and ddof >= 0 and ddof < length else 1
+    ddof = int(ddof) if isinstance(ddof, int) and ddof >= 0 and ddof < length else 0
     min_periods = (
         int(kwargs["min_periods"])
         if "min_periods" in kwargs and kwargs["min_periods"] is not None

--- a/pandas_ta_classic/trend/psar.py
+++ b/pandas_ta_classic/trend/psar.py
@@ -71,7 +71,8 @@ def psar(
                 ep = low_
                 af = min(af + af0, max_af)
 
-            _sar = max(high.iloc[row - 1], high.iloc[row - 2], _sar)
+            # Guard row==1: row-2 would be -1 (last element) without the clamp.
+            _sar = max(high.iloc[row - 1], high.iloc[max(0, row - 2)], _sar)
         else:
             _sar = sar + af * (ep - sar)
             reverse = low_ < _sar
@@ -80,7 +81,8 @@ def psar(
                 ep = high_
                 af = min(af + af0, max_af)
 
-            _sar = min(low.iloc[row - 1], low.iloc[row - 2], _sar)
+            # Guard row==1: row-2 would be -1 (last element) without the clamp.
+            _sar = min(low.iloc[row - 1], low.iloc[max(0, row - 2)], _sar)
 
         if reverse:
             _sar = ep

--- a/pandas_ta_classic/trend/psar.py
+++ b/pandas_ta_classic/trend/psar.py
@@ -27,6 +27,9 @@ def psar(
     max_af = float(max_af) if max_af and max_af > 0 else 0.2
     offset = get_offset(offset)
 
+    if high is None or low is None:
+        return None
+
     def _falling(high: Series, low: Series, drift: int = 1) -> bool:
         """Returns the last -DM value"""
         # Not to be confused with ta.falling()
@@ -36,13 +39,13 @@ def psar(
         return _dmn > 0
 
     # Falling if the first NaN -DM is positive
-    falling = _falling(high.iloc[:2], low.iloc[:2])
+    falling = _falling(high.iloc[:2], low.iloc[:2]) if len(high) > 1 else False
     if falling:
         sar = high.iloc[0]
-        ep = low.iloc[0]
+        ep = low.iloc[1] if len(low) > 1 else low.iloc[0]
     else:
         sar = low.iloc[0]
-        ep = high.iloc[0]
+        ep = high.iloc[1] if len(high) > 1 else high.iloc[0]
 
     if close is not None:
         close = verify_series(close)

--- a/pandas_ta_classic/volume/adosc.py
+++ b/pandas_ta_classic/volume/adosc.py
@@ -4,7 +4,6 @@ from typing import Any, Optional
 from pandas import Series
 from .ad import ad
 from pandas_ta_classic import Imports
-from pandas_ta_classic.overlap.ema import ema
 from pandas_ta_classic.utils import get_offset, verify_series
 
 

--- a/pandas_ta_classic/volume/adosc.py
+++ b/pandas_ta_classic/volume/adosc.py
@@ -43,10 +43,26 @@ def adosc(
 
         adosc = ADOSC(high, low, close, volume, fast, slow)
     else:
+        import numpy as np
+
         ad_ = ad(high=high, low=low, close=close, volume=volume, open_=open_)
-        fast_ad = ema(close=ad_, length=fast, **kwargs)
-        slow_ad = ema(close=ad_, length=slow, **kwargs)
-        adosc = fast_ad - slow_ad
+        ad_arr = ad_.to_numpy(dtype=float)
+        m = ad_arr.shape[0]
+
+        # TA-Lib ADOSC: seed both EMAs with AD[0] (scalar seed, not SMA)
+        fastk = 2.0 / (fast + 1)
+        slowk = 2.0 / (slow + 1)
+        fast_ema = ad_arr[0]
+        slow_ema = ad_arr[0]
+        result = np.full(m, np.nan)
+
+        for i in range(1, m):
+            fast_ema = fastk * ad_arr[i] + (1 - fastk) * fast_ema
+            slow_ema = slowk * ad_arr[i] + (1 - slowk) * slow_ema
+            if i >= slow - 1:
+                result[i] = fast_ema - slow_ema
+
+        adosc = Series(result, index=close.index)
 
     # Offset
     if offset != 0:


### PR DESCRIPTION
## Summary
Aligns native indicator implementations with TA-Lib's reference algorithms:

- **cmo**: use RMA smoothing to match TA-Lib algorithm
- **dm**: scale native DM output to match TA-Lib Wilder convention
- **cdl_doji**: match TA-Lib detection algorithm exactly
- **linreg**: fix off-by-one in x-indexing and return angle in degrees
- **stdev/variance**: align ddof with TA-Lib
- **psar**: rewrite initial EP to match TA-Lib SAR convention
- **macd**: match TA-Lib EMA seeding exactly
- **adosc**: match TA-Lib EMA seeding exactly

## Test plan
- [x] `pytest` passes on Python 3.9–3.13
- [x] Each indicator correlates >0.99 with TA-Lib output (where TA-Lib is installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)