### PR TITLE
feat(candles): add 59 native TA-Lib candle pattern implementations

### DIFF
--- a/pandas_ta_classic/_meta.py
+++ b/pandas_ta_classic/_meta.py
@@ -103,12 +103,19 @@ def _build_category_dict():
         if category_name not in valid_categories:
             continue
 
-        # Find all .py files in this category (excluding __init__.py)
+        # Find all .py files in this category (excluding __init__.py and
+        # internal helpers).  For candles, individual cdl_* pattern files
+        # (e.g. cdl_engulfing) are sub-patterns accessed via cdl_pattern()
+        # and should not appear as top-level indicators.
+        _candle_top = {"cdl_doji", "cdl_inside", "cdl_pattern", "cdl_z", "ha"}
         indicators = []
         for file_path in category_path.glob("*.py"):
-            if file_path.name != "__init__.py":
-                # Remove .py extension to get the indicator name
-                indicators.append(file_path.stem)
+            if file_path.name.startswith("_"):
+                continue
+            stem = file_path.stem
+            if category_name == "candles" and stem not in _candle_top:
+                continue
+            indicators.append(stem)
 
         # Sort indicators alphabetically for consistency
         if indicators:

--- a/pandas_ta_classic/candles/_cdl_math.py
+++ b/pandas_ta_classic/candles/_cdl_math.py
@@ -4,6 +4,7 @@
 Underscore prefix ensures ``_build_category_dict()`` in ``_meta.py`` ignores this
 file during auto-discovery.
 """
+
 from typing import Any, Callable, Optional
 
 from enum import IntEnum

--- a/pandas_ta_classic/candles/_cdl_math.py
+++ b/pandas_ta_classic/candles/_cdl_math.py
@@ -14,7 +14,6 @@ from pandas import Series
 
 from pandas_ta_classic.utils import get_offset, verify_series
 
-
 # ---------------------------------------------------------------------------
 # Enums (mirror TA-Lib ta_defs.h)
 # ---------------------------------------------------------------------------

--- a/pandas_ta_classic/candles/_cdl_math.py
+++ b/pandas_ta_classic/candles/_cdl_math.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+"""Core candle pattern framework — translates TA-Lib's C candle macros to Python.
+
+Underscore prefix ensures ``_build_category_dict()`` in ``_meta.py`` ignores this
+file during auto-discovery.
+"""
+from typing import Any, Callable, Optional
+
+from enum import IntEnum
+
+import numpy as np
+from pandas import Series
+
+from pandas_ta_classic.utils import get_offset, verify_series
+
+
+# ---------------------------------------------------------------------------
+# Enums (mirror TA-Lib ta_defs.h)
+# ---------------------------------------------------------------------------
+
+
+class RangeType(IntEnum):
+    RealBody = 0
+    HighLow = 1
+    Shadows = 2
+
+
+class CandleSetting(IntEnum):
+    BodyLong = 0
+    BodyVeryLong = 1
+    BodyShort = 2
+    BodyDoji = 3
+    ShadowLong = 4
+    ShadowVeryLong = 5
+    ShadowShort = 6
+    ShadowVeryShort = 7
+    Near = 8
+    Far = 9
+    Equal = 10
+
+
+# ---------------------------------------------------------------------------
+# Default settings  (range_type, avg_period, factor)
+# From TA-Lib ta_global.c  TA_CandleDefaultSettings
+# ---------------------------------------------------------------------------
+
+CANDLE_DEFAULTS = {
+    CandleSetting.BodyLong: (RangeType.RealBody, 10, 1.0),
+    CandleSetting.BodyVeryLong: (RangeType.RealBody, 10, 3.0),
+    CandleSetting.BodyShort: (RangeType.RealBody, 10, 1.0),
+    CandleSetting.BodyDoji: (RangeType.HighLow, 10, 0.1),
+    CandleSetting.ShadowLong: (RangeType.RealBody, 0, 1.0),
+    CandleSetting.ShadowVeryLong: (RangeType.RealBody, 0, 2.0),
+    CandleSetting.ShadowShort: (RangeType.Shadows, 10, 1.0),
+    CandleSetting.ShadowVeryShort: (RangeType.HighLow, 10, 0.1),
+    CandleSetting.Near: (RangeType.HighLow, 5, 0.2),
+    CandleSetting.Far: (RangeType.HighLow, 5, 0.6),
+    CandleSetting.Equal: (RangeType.HighLow, 5, 0.05),
+}
+
+
+# ---------------------------------------------------------------------------
+# Pre-computed average parameters (module-level for direct access in _detect)
+# ---------------------------------------------------------------------------
+
+AVG_PERIOD = {s: CANDLE_DEFAULTS[s][1] for s in CandleSetting}
+
+AVG_FACTOR = {}
+for _s in CandleSetting:
+    _rt, _ap, _f = CANDLE_DEFAULTS[_s]
+    _d = 2.0 if _rt == RangeType.Shadows else 1.0
+    AVG_FACTOR[_s] = _f / (_ap * _d) if _ap != 0 else _f / _d
+del _s, _rt, _ap, _f, _d
+
+
+# ---------------------------------------------------------------------------
+# CandleArrays — pre-computed numpy arrays + TA-Lib macro equivalents
+# ---------------------------------------------------------------------------
+
+
+class CandleArrays:
+    """Holds pre-computed OHLC-derived numpy arrays and provides TA-Lib
+    macro equivalents (``candle_range``, ``candle_average``, etc.)."""
+
+    __slots__ = (
+        "open",
+        "high",
+        "low",
+        "close",
+        "real_body",
+        "upper_shadow",
+        "lower_shadow",
+        "hl_range",
+        "shadow_range",
+        "body_high",
+        "body_low",
+        "color",
+        "_ranges",
+    )
+
+    def __init__(
+        self,
+        open_: np.ndarray,
+        high: np.ndarray,
+        low: np.ndarray,
+        close: np.ndarray,
+    ) -> None:
+        self.open = open_
+        self.high = high
+        self.low = low
+        self.close = close
+
+        self.body_high = np.maximum(close, open_)
+        self.body_low = np.minimum(close, open_)
+        self.real_body = np.abs(close - open_)
+        self.upper_shadow = high - self.body_high
+        self.lower_shadow = self.body_low - low
+        self.hl_range = high - low
+        self.shadow_range = self.upper_shadow + self.lower_shadow
+        # +1 = bullish (close >= open), -1 = bearish
+        self.color = np.where(close >= open_, 1, -1)
+
+        # Pre-computed range array for each CandleSetting (eliminates
+        # per-call branching in candle_range).
+        _rt_arrays = {
+            RangeType.RealBody: self.real_body,
+            RangeType.HighLow: self.hl_range,
+            RangeType.Shadows: self.shadow_range,
+        }
+        self._ranges = {s: _rt_arrays[CANDLE_DEFAULTS[s][0]] for s in CandleSetting}
+
+    # -- TA-Lib macro: TA_CANDLERANGE --
+    def candle_range(self, setting: CandleSetting, i: int) -> float:
+        return self._ranges[setting][i]
+
+    # -- TA-Lib macro: TA_CANDLEAVERAGE --
+    def candle_average(
+        self, setting: CandleSetting, period_total: float, i: int
+    ) -> float:
+        """Exact replica of TA-Lib's TA_CANDLEAVERAGE macro.
+
+        Formula: ``factor * (sum/period) / (2 if Shadows else 1)``
+        When ``avgPeriod == 0``, uses ``candle_range(setting, i)`` instead of
+        ``sum/period``.
+        """
+        ap = AVG_PERIOD[setting]
+        if ap != 0:
+            return AVG_FACTOR[setting] * period_total
+        return AVG_FACTOR[setting] * self._ranges[setting][i]
+
+    # -- TA-Lib macro: TA_REALBODYGAPUP --
+    def real_body_gap_up(self, i2: int, i1: int) -> bool:
+        return self.body_low[i2] > self.body_high[i1]
+
+    # -- TA-Lib macro: TA_REALBODYGAPDOWN --
+    def real_body_gap_down(self, i2: int, i1: int) -> bool:
+        return self.body_high[i2] < self.body_low[i1]
+
+    # -- TA-Lib macro: TA_CANDLEGAPUP --
+    def candle_gap_up(self, i2: int, i1: int) -> bool:
+        return self.low[i2] > self.high[i1]
+
+    # -- TA-Lib macro: TA_CANDLEGAPDOWN --
+    def candle_gap_down(self, i2: int, i1: int) -> bool:
+        return self.high[i2] < self.low[i1]
+
+
+# ---------------------------------------------------------------------------
+# Lookback helper
+# ---------------------------------------------------------------------------
+
+
+def candle_avg_period(setting: CandleSetting) -> int:
+    return CANDLE_DEFAULTS[setting][1]
+
+
+# ---------------------------------------------------------------------------
+# run_pattern — top-level helper that every cdl_*.py calls
+# ---------------------------------------------------------------------------
+
+
+def run_pattern(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    detect_fn: Callable,
+    name: str,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Validate OHLC, build CandleArrays, run *detect_fn*, finalize result.
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        detect_fn: ``fn(ca: CandleArrays, out: np.ndarray, **kwargs)`` that
+            fills *out* in-place with pattern signals (100 / -100 / 0).
+        name: Column name, e.g. ``"CDL_HAMMER"``.
+        scalar: Multiplier for output values. Default: 100.
+        offset: How many periods to shift the result.
+        **kwargs: Forwarded for fillna / fill_method handling.
+
+    Returns:
+        A pandas Series with the pattern result, or None if validation fails.
+    """
+    open_ = verify_series(open_)
+    high = verify_series(high)
+    low = verify_series(low)
+    close = verify_series(close)
+
+    if open_ is None or high is None or low is None or close is None:
+        return None
+
+    offset = get_offset(offset)
+    scalar = float(scalar) if scalar else 100
+
+    ca = CandleArrays(
+        open_.to_numpy(dtype=float),
+        high.to_numpy(dtype=float),
+        low.to_numpy(dtype=float),
+        close.to_numpy(dtype=float),
+    )
+
+    n = len(close)
+    out = np.zeros(n, dtype=np.double)
+
+    detect_fn(ca, out, **kwargs)
+
+    # Scale output (TA-Lib outputs ±100; scalar lets callers adjust)
+    if scalar != 100:
+        mask = out != 0
+        out[mask] = out[mask] / 100.0 * scalar
+
+    result = Series(out, index=close.index)
+
+    # Offset
+    if offset != 0:
+        result = result.shift(offset)
+
+    # Handle fills
+    if "fillna" in kwargs:
+        result.fillna(kwargs["fillna"], inplace=True)
+    if "fill_method" in kwargs:
+        if kwargs["fill_method"] == "ffill":
+            result.ffill(inplace=True)
+        elif kwargs["fill_method"] == "bfill":
+            result.bfill(inplace=True)
+
+    # Name and Categorize it
+    result.name = name
+    result.category = "candles"
+
+    return result

--- a/pandas_ta_classic/candles/cdl_2crows.py
+++ b/pandas_ta_classic/candles/cdl_2crows.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Lookback: TA_CANDLEAVGPERIOD(BodyLong) + 2
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    lookback = body_long_period + 2
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    body_long_trail = start_idx - 2 - body_long_period
+    body_long_total = float(arr_bl[body_long_trail : start_idx - 2].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 2] == 1  # 1st: white
+            and ca.real_body[i - 2]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total  # long
+            and ca.color[i - 1] == -1  # 2nd: black
+            and body_lo[i - 1] > body_hi[i - 2]  # gapping up
+            and ca.color[i] == -1  # 3rd: black
+            and ca.open[i] < ca.open[i - 1]
+            and ca.open[i] > ca.close[i - 1]  # opening within 2nd rb
+            and ca.close[i] > ca.open[i - 2]
+            and ca.close[i] < ca.close[i - 2]  # closing within 1st rb
+        ):
+            out[i] = -100
+
+        body_long_total += arr_bl[i - 2] - arr_bl[body_long_trail]
+        body_long_trail += 1
+
+
+def cdl_2crows(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Two Crows"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_2CROWS",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_3blackcrows.py
+++ b/pandas_ta_classic/candles/cdl_3blackcrows.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Lookback: TA_CANDLEAVGPERIOD(ShadowVeryShort) + 3
+    svs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    lookback = svs_period + 3
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+
+    svs_trail = start_idx - svs_period
+
+    # Seed ShadowVeryShort totals for i-2, i-1, i (indices 2, 1, 0)
+    svs_total_2 = float(arr_svs[svs_trail - 2 : start_idx - 2].sum())
+    svs_total_1 = float(arr_svs[svs_trail - 1 : start_idx - 1].sum())
+    svs_total_0 = float(arr_svs[svs_trail:start_idx].sum())
+    O = ca.open
+    H = ca.high
+    C = ca.close
+
+    for i in range(start_idx, len(out)):
+        if (
+            # Prior candle (i-3) is white
+            ca.color[i - 3] == 1
+            # 1st black
+            and ca.color[i - 2] == -1
+            # very short lower shadow
+            and ca.lower_shadow[i - 2]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total_2
+            # 2nd black
+            and ca.color[i - 1] == -1
+            # very short lower shadow
+            and ca.lower_shadow[i - 1]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total_1
+            # 3rd black
+            and ca.color[i] == -1
+            # very short lower shadow
+            and ca.lower_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total_0
+            # 2nd black opens within 1st black's real body
+            and O[i - 1] < O[i - 2]
+            and O[i - 1] > C[i - 2]
+            # 3rd black opens within 2nd black's real body
+            and O[i] < O[i - 1]
+            and O[i] > C[i - 1]
+            # 1st black closes under prior candle's high
+            and H[i - 3] > C[i - 2]
+            # Three declining closes
+            and C[i - 2] > C[i - 1]
+            and C[i - 1] > C[i]
+        ):
+            out[i] = -100
+
+        # Update totals: add current range, subtract trailing range
+        svs_total_2 += arr_svs[i - 2] - arr_svs[svs_trail - 2]
+        svs_total_1 += arr_svs[i - 1] - arr_svs[svs_trail - 1]
+        svs_total_0 += arr_svs[i] - arr_svs[svs_trail]
+        svs_trail += 1
+
+
+def cdl_3blackcrows(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Three Black Crows
+
+    Three consecutive declining black (bearish) candlesticks, each with
+    very short lower shadows. Each candle after the first opens within
+    the prior candle's real body. The first candle's close is below the
+    preceding white candle's high.
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        scalar: Multiplier for output values. Default: 100.
+        offset: Number of periods to shift the result.
+
+    Returns:
+        A Series with -100 (bearish) / 0, or None.
+
+    Example:
+        >>> result = cdl_3blackcrows(df.open, df.high, df.low, df.close)
+    """
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_3BLACKCROWS",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_3inside.py
+++ b/pandas_ta_classic/candles/cdl_3inside.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    lookback = max(body_long_period, body_short_period) + 2
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    body_long_trail = start_idx - 2 - body_long_period
+    body_short_trail = start_idx - 1 - body_short_period
+    body_long_total = float(arr_bl[body_long_trail : start_idx - 2].sum())
+    body_short_total = float(arr_bs[body_short_trail : start_idx - 1].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i - 2] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.real_body[i - 1]
+            <= AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            and body_hi[i - 1] < body_hi[i - 2]
+            and body_lo[i - 1] > body_lo[i - 2]
+            and (
+                (
+                    ca.color[i - 2] == 1
+                    and ca.color[i] == -1
+                    and ca.close[i] < ca.open[i - 2]
+                )
+                or (
+                    ca.color[i - 2] == -1
+                    and ca.color[i] == 1
+                    and ca.close[i] > ca.open[i - 2]
+                )
+            )
+        ):
+            out[i] = -ca.color[i - 2] * 100
+
+        body_long_total += arr_bl[i - 2] - arr_bl[body_long_trail]
+        body_short_total += arr_bs[i - 1] - arr_bs[body_short_trail]
+        body_long_trail += 1
+        body_short_trail += 1
+
+
+def cdl_3inside(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Three Inside Up/Down"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_3INSIDE",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_3linestrike.py
+++ b/pandas_ta_classic/candles/cdl_3linestrike.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Lookback: TA_CANDLEAVGPERIOD(Near) + 3
+    near_period = candle_avg_period(CandleSetting.Near)
+    lookback = near_period + 3
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_nr = ca._ranges[CandleSetting.Near]
+
+    near_trail = start_idx - near_period
+
+    # Seed Near totals for i-3 and i-2 (indices 3, 2)
+    near_total_3 = float(arr_nr[near_trail - 3 : start_idx - 3].sum())
+    near_total_2 = float(arr_nr[near_trail - 2 : start_idx - 2].sum())
+    O = ca.open
+    C = ca.close
+
+    for i in range(start_idx, len(out)):
+        if (
+            # Three candles with same color
+            ca.color[i - 3] == ca.color[i - 2]
+            and ca.color[i - 2] == ca.color[i - 1]
+            # 4th opposite color
+            and ca.color[i] == -ca.color[i - 1]
+            # 2nd opens within/near 1st real body
+            and O[i - 2]
+            >= min(O[i - 3], C[i - 3]) - AVG_FACTOR[CandleSetting.Near] * near_total_3
+            and O[i - 2]
+            <= max(O[i - 3], C[i - 3]) + AVG_FACTOR[CandleSetting.Near] * near_total_3
+            # 3rd opens within/near 2nd real body
+            and O[i - 1]
+            >= min(O[i - 2], C[i - 2]) - AVG_FACTOR[CandleSetting.Near] * near_total_2
+            and O[i - 1]
+            <= max(O[i - 2], C[i - 2]) + AVG_FACTOR[CandleSetting.Near] * near_total_2
+            and (
+                (
+                    # If three white
+                    ca.color[i - 1] == 1
+                    # Consecutive higher closes
+                    and C[i - 1] > C[i - 2]
+                    and C[i - 2] > C[i - 3]
+                    # 4th opens above prior close
+                    and O[i] > C[i - 1]
+                    # 4th closes below 1st open
+                    and C[i] < O[i - 3]
+                )
+                or (
+                    # If three black
+                    ca.color[i - 1] == -1
+                    # Consecutive lower closes
+                    and C[i - 1] < C[i - 2]
+                    and C[i - 2] < C[i - 3]
+                    # 4th opens below prior close
+                    and O[i] < C[i - 1]
+                    # 4th closes above 1st open
+                    and C[i] > O[i - 3]
+                )
+            )
+        ):
+            out[i] = ca.color[i - 1] * 100
+
+        # Update totals: add current range, subtract trailing range
+        near_total_3 += arr_nr[i - 3] - arr_nr[near_trail - 3]
+        near_total_2 += arr_nr[i - 2] - arr_nr[near_trail - 2]
+        near_trail += 1
+
+
+def cdl_3linestrike(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Three-Line Strike
+
+    Three same-colored candles with consecutively higher (white) or lower
+    (black) closes, each opening within or near the prior real body. The
+    fourth candle is the opposite color and engulfs the entire 3-candle
+    move (opening beyond the third's close, closing beyond the first's
+    open).
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        scalar: Multiplier for output values. Default: 100.
+        offset: Number of periods to shift the result.
+
+    Returns:
+        A Series with +100 (bullish) / -100 (bearish) / 0, or None.
+
+    Example:
+        >>> result = cdl_3linestrike(df.open, df.high, df.low, df.close)
+    """
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_3LINESTRIKE",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_3outside.py
+++ b/pandas_ta_classic/candles/cdl_3outside.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    start_idx = 3
+    if start_idx >= len(out):
+        return
+
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 1] == 1
+            and ca.color[i - 2] == -1
+            and ca.close[i - 1] > ca.open[i - 2]
+            and ca.open[i - 1] < ca.close[i - 2]
+            and ca.close[i] > ca.close[i - 1]
+        ) or (
+            ca.color[i - 1] == -1
+            and ca.color[i - 2] == 1
+            and ca.open[i - 1] > ca.close[i - 2]
+            and ca.close[i - 1] < ca.open[i - 2]
+            and ca.close[i] < ca.close[i - 1]
+        ):
+            out[i] = ca.color[i - 1] * 100
+
+
+def cdl_3outside(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Three Outside Up/Down"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_3OUTSIDE",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_3starsinsouth.py
+++ b/pandas_ta_classic/candles/cdl_3starsinsouth.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Settings and their avg periods
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    shadow_long_period = candle_avg_period(CandleSetting.ShadowLong)
+    shadow_vshort_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+
+    # Lookback: max(all avg periods) + 2
+    lookback = (
+        max(
+            shadow_vshort_period,
+            shadow_long_period,
+            body_long_period,
+            body_short_period,
+        )
+        + 2
+    )
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    arr_sl = ca._ranges[CandleSetting.ShadowLong]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+
+    # Trailing indices
+    body_long_trail = start_idx - body_long_period
+    shadow_long_trail = start_idx - shadow_long_period
+    shadow_vshort_trail = start_idx - shadow_vshort_period
+    body_short_trail = start_idx - body_short_period
+
+    # Seed totals
+    # BodyLong: applied to i-2
+    body_long_total = float(arr_bl[body_long_trail - 2 : start_idx - 2].sum())
+    # ShadowLong: applied to i-2
+    shadow_long_total = float(arr_sl[shadow_long_trail - 2 : start_idx - 2].sum())
+    # ShadowVeryShort[1]: applied to i-1; ShadowVeryShort[0]: applied to i
+    shadow_vshort_total_1 = float(
+        arr_svs[shadow_vshort_trail - 1 : start_idx - 1].sum()
+    )
+    shadow_vshort_total_0 = float(arr_svs[shadow_vshort_trail:start_idx].sum())
+    # BodyShort: applied to i
+    body_short_total = float(arr_bs[body_short_trail:start_idx].sum())
+    O = ca.open
+    H = ca.high
+    L = ca.low
+    C = ca.close
+
+    for i in range(start_idx, len(out)):
+        if (
+            # All three candles are black
+            ca.color[i - 2] == -1
+            and ca.color[i - 1] == -1
+            and ca.color[i] == -1
+            # 1st: long body
+            and ca.real_body[i - 2]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            # 1st: long lower shadow
+            and ca.lower_shadow[i - 2]
+            > AVG_FACTOR[CandleSetting.ShadowLong] * arr_sl[i - 2]
+            # 2nd: smaller candle
+            and ca.real_body[i - 1] < ca.real_body[i - 2]
+            # 2nd: opens higher than 1st close but within 1st range
+            and O[i - 1] > C[i - 2]
+            and O[i - 1] <= H[i - 2]
+            # 2nd: trades lower than 1st close
+            and L[i - 1] < C[i - 2]
+            # 2nd: but not lower than 1st low
+            and L[i - 1] >= L[i - 2]
+            # 2nd: has a lower shadow (not very short)
+            and ca.lower_shadow[i - 1]
+            > AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vshort_total_1
+            # 3rd: small marubozu (short body)
+            and ca.real_body[i] < AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            # 3rd: very short lower shadow
+            and ca.lower_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vshort_total_0
+            # 3rd: very short upper shadow
+            and ca.upper_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vshort_total_0
+            # 3rd: engulfed by 2nd candle's range
+            and L[i] > L[i - 1]
+            and H[i] < H[i - 1]
+        ):
+            out[i] = 100  # Always bullish
+
+        # Update totals
+        body_long_total += arr_bl[i - 2] - arr_bl[body_long_trail - 2]
+        shadow_long_total += arr_sl[i - 2] - arr_sl[shadow_long_trail - 2]
+
+        shadow_vshort_total_1 += arr_svs[i - 1] - arr_svs[shadow_vshort_trail - 1]
+        shadow_vshort_total_0 += arr_svs[i] - arr_svs[shadow_vshort_trail]
+
+        body_short_total += arr_bs[i] - arr_bs[body_short_trail]
+
+        body_long_trail += 1
+        shadow_long_trail += 1
+        shadow_vshort_trail += 1
+        body_short_trail += 1
+
+
+def cdl_3starsinsouth(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Three Stars In The South
+
+    A 3-candle bullish reversal pattern. All three candles are bearish.
+    The first is a long black candle with a long lower shadow. The second
+    is a smaller black candle that opens higher than the first's close but
+    within the first's range, trades lower than the first's close but not
+    lower than its low, and has a lower shadow. The third is a small black
+    marubozu engulfed by the second candle's range.
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        scalar: Multiplier for output values. Default: 100.
+        offset: Number of periods to shift the result.
+
+    Returns:
+        A Series with +100 (bullish) / 0, or None.
+
+    Example:
+        >>> result = cdl_3starsinsouth(df.open, df.high, df.low, df.close)
+    """
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_3STARSINSOUTH",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_3whitesoldiers.py
+++ b/pandas_ta_classic/candles/cdl_3whitesoldiers.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Settings and their avg periods
+    svs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    far_period = candle_avg_period(CandleSetting.Far)
+    near_period = candle_avg_period(CandleSetting.Near)
+
+    # Lookback: max(all avg periods) + 2
+    lookback = max(svs_period, body_short_period, far_period, near_period) + 2
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    arr_fr = ca._ranges[CandleSetting.Far]
+    arr_nr = ca._ranges[CandleSetting.Near]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+
+    # Trailing indices
+    svs_trail = start_idx - svs_period
+    near_trail = start_idx - near_period
+    far_trail = start_idx - far_period
+    body_short_trail = start_idx - body_short_period
+
+    # Seed ShadowVeryShort totals [2], [1], [0]
+    svs_total_2 = float(arr_svs[svs_trail - 2 : start_idx - 2].sum())
+    svs_total_1 = float(arr_svs[svs_trail - 1 : start_idx - 1].sum())
+    svs_total_0 = float(arr_svs[svs_trail:start_idx].sum())
+    # Seed Near totals [2], [1] (not [0])
+    near_total_2 = float(arr_nr[near_trail - 2 : start_idx - 2].sum())
+    near_total_1 = float(arr_nr[near_trail - 1 : start_idx - 1].sum())
+    # Seed Far totals [2], [1] (not [0])
+    far_total_2 = float(arr_fr[far_trail - 2 : start_idx - 2].sum())
+    far_total_1 = float(arr_fr[far_trail - 1 : start_idx - 1].sum())
+    # Seed BodyShort total
+    body_short_total = float(arr_bs[body_short_trail:start_idx].sum())
+    O = ca.open
+    C = ca.close
+
+    for i in range(start_idx, len(out)):
+        if (
+            # 1st white
+            ca.color[i - 2] == 1
+            # 1st: very short upper shadow
+            and ca.upper_shadow[i - 2]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total_2
+            # 2nd white
+            and ca.color[i - 1] == 1
+            # 2nd: very short upper shadow
+            and ca.upper_shadow[i - 1]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total_1
+            # 3rd white
+            and ca.color[i] == 1
+            # 3rd: very short upper shadow
+            and ca.upper_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total_0
+            # Consecutive higher closes
+            and C[i] > C[i - 1]
+            and C[i - 1] > C[i - 2]
+            # 2nd opens within/near 1st real body
+            and O[i - 1] > O[i - 2]
+            and O[i - 1] <= C[i - 2] + AVG_FACTOR[CandleSetting.Near] * near_total_2
+            # 3rd opens within/near 2nd real body
+            and O[i] > O[i - 1]
+            and O[i] <= C[i - 1] + AVG_FACTOR[CandleSetting.Near] * near_total_1
+            # 2nd not far shorter than 1st
+            and ca.real_body[i - 1]
+            > ca.real_body[i - 2] - AVG_FACTOR[CandleSetting.Far] * far_total_2
+            # 3rd not far shorter than 2nd
+            and ca.real_body[i]
+            > ca.real_body[i - 1] - AVG_FACTOR[CandleSetting.Far] * far_total_1
+            # 3rd: not short real body
+            and ca.real_body[i] > AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+        ):
+            out[i] = 100  # Always bullish
+
+        # Update ShadowVeryShort totals [2], [1], [0]
+        svs_total_2 += arr_svs[i - 2] - arr_svs[svs_trail - 2]
+        svs_total_1 += arr_svs[i - 1] - arr_svs[svs_trail - 1]
+        svs_total_0 += arr_svs[i] - arr_svs[svs_trail]
+
+        # Update Far and Near totals [2], [1]
+        far_total_2 += arr_fr[i - 2] - arr_fr[far_trail - 2]
+        far_total_1 += arr_fr[i - 1] - arr_fr[far_trail - 1]
+        near_total_2 += arr_nr[i - 2] - arr_nr[near_trail - 2]
+        near_total_1 += arr_nr[i - 1] - arr_nr[near_trail - 1]
+
+        # Update BodyShort total
+        body_short_total += arr_bs[i] - arr_bs[body_short_trail]
+
+        svs_trail += 1
+        near_trail += 1
+        far_trail += 1
+        body_short_trail += 1
+
+
+def cdl_3whitesoldiers(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Three Advancing White Soldiers
+
+    A 3-candle bullish reversal pattern. Three consecutive white
+    (bullish) candles with consecutively higher closes. Each candle
+    opens within or near the previous real body and has very short
+    upper shadows. Each candle must not be far shorter than the prior
+    one, and the third must not be short.
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        scalar: Multiplier for output values. Default: 100.
+        offset: Number of periods to shift the result.
+
+    Returns:
+        A Series with +100 (bullish) / 0, or None.
+
+    Example:
+        >>> result = cdl_3whitesoldiers(df.open, df.high, df.low, df.close)
+    """
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_3WHITESOLDIERS",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_abandonedbaby.py
+++ b/pandas_ta_classic/candles/cdl_abandonedbaby.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    penetration = kwargs.get("penetration", 0.3)
+
+    # Lookback: max(BodyDoji, BodyLong, BodyShort) + 2
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    body_doji_period = candle_avg_period(CandleSetting.BodyDoji)
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    lookback = max(body_doji_period, body_long_period, body_short_period) + 2
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bd = ca._ranges[CandleSetting.BodyDoji]
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    hi = ca.high
+    lo = ca.low
+
+    # Trailing indices: each setting has its own trail
+    # BodyLong at offset i-2: trail = startIdx - 2 - period
+    body_long_trail = start_idx - 2 - body_long_period
+    # BodyDoji at offset i-1: trail = startIdx - 1 - period
+    body_doji_trail = start_idx - 1 - body_doji_period
+    # BodyShort at offset i: trail = startIdx - period
+    body_short_trail = start_idx - body_short_period
+
+    # Seed totals
+    body_long_total = float(arr_bl[body_long_trail : start_idx - 2].sum())
+    body_doji_total = float(arr_bd[body_doji_trail : start_idx - 1].sum())
+    body_short_total = float(arr_bs[body_short_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        # Pattern detection
+        if (
+            # 1st: long real body
+            ca.real_body[i - 2] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            # 2nd: doji
+            and ca.real_body[i - 1]
+            <= AVG_FACTOR[CandleSetting.BodyDoji] * body_doji_total
+            # 3rd: longer than short
+            and ca.real_body[i] > AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            and (
+                (
+                    # Bullish 1st white, bearish 3rd black
+                    ca.color[i - 2] == 1
+                    and ca.color[i] == -1
+                    # 3rd closes well within 1st rb
+                    and ca.close[i]
+                    < ca.close[i - 2] - ca.real_body[i - 2] * penetration
+                    # upside candle gap between 1st and 2nd
+                    and lo[i - 1] > hi[i - 2]
+                    # downside candle gap between 2nd and 3rd
+                    and hi[i] < lo[i - 1]
+                )
+                or (
+                    # Bearish 1st black, bullish 3rd white
+                    ca.color[i - 2] == -1
+                    and ca.color[i] == 1
+                    # 3rd closes well within 1st rb
+                    and ca.close[i]
+                    > ca.close[i - 2] + ca.real_body[i - 2] * penetration
+                    # downside candle gap between 1st and 2nd
+                    and hi[i - 1] < lo[i - 2]
+                    # upside candle gap between 2nd and 3rd
+                    and lo[i] > hi[i - 1]
+                )
+            )
+        ):
+            out[i] = ca.color[i] * 100
+
+        # Update trailing windows
+        body_long_total += arr_bl[i - 2] - arr_bl[body_long_trail]
+        body_doji_total += arr_bd[i - 1] - arr_bd[body_doji_trail]
+        body_short_total += arr_bs[i] - arr_bs[body_short_trail]
+        body_long_trail += 1
+        body_doji_trail += 1
+        body_short_trail += 1
+
+
+def cdl_abandonedbaby(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    penetration: Optional[float] = None,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Abandoned Baby
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        penetration: Percentage of penetration within the first candle's
+            real body. Default: 0.3
+        scalar: Multiplier for output values. Default: 100.
+        offset: How many periods to shift the result.
+
+    Returns:
+        A pandas Series with +100 (bullish) or -100 (bearish) or 0.
+    """
+    if penetration is None:
+        penetration = 0.3
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_ABANDONEDBABY",
+        scalar=scalar,
+        offset=offset,
+        penetration=penetration,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_advanceblock.py
+++ b/pandas_ta_classic/candles/cdl_advanceblock.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Settings and their avg periods
+    shadow_short_period = candle_avg_period(CandleSetting.ShadowShort)
+    shadow_long_period = candle_avg_period(CandleSetting.ShadowLong)
+    near_period = candle_avg_period(CandleSetting.Near)
+    far_period = candle_avg_period(CandleSetting.Far)
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+
+    # Lookback: max(all avg periods) + 2
+    lookback = (
+        max(
+            shadow_long_period,
+            shadow_short_period,
+            far_period,
+            near_period,
+            body_long_period,
+        )
+        + 2
+    )
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_fr = ca._ranges[CandleSetting.Far]
+    arr_nr = ca._ranges[CandleSetting.Near]
+    arr_sl = ca._ranges[CandleSetting.ShadowLong]
+    arr_ss = ca._ranges[CandleSetting.ShadowShort]
+
+    # Trailing indices
+    shadow_short_trail = start_idx - shadow_short_period
+    shadow_long_trail = start_idx - shadow_long_period
+    near_trail = start_idx - near_period
+    far_trail = start_idx - far_period
+    body_long_trail = start_idx - body_long_period
+
+    # Seed ShadowShort totals [2], [1], [0]
+    ss_total_2 = float(arr_ss[shadow_short_trail - 2 : start_idx - 2].sum())
+    ss_total_1 = float(arr_ss[shadow_short_trail - 1 : start_idx - 1].sum())
+    ss_total_0 = float(arr_ss[shadow_short_trail:start_idx].sum())
+    # Seed ShadowLong totals [1], [0]
+    sl_total_1 = float(arr_sl[shadow_long_trail - 1 : start_idx - 1].sum())
+    sl_total_0 = float(arr_sl[shadow_long_trail:start_idx].sum())
+    # Seed Near totals [2], [1]
+    near_total_2 = float(arr_nr[near_trail - 2 : start_idx - 2].sum())
+    near_total_1 = float(arr_nr[near_trail - 1 : start_idx - 1].sum())
+    # Seed Far totals [2], [1]
+    far_total_2 = float(arr_fr[far_trail - 2 : start_idx - 2].sum())
+    far_total_1 = float(arr_fr[far_trail - 1 : start_idx - 1].sum())
+    # Seed BodyLong total (applied to i-2)
+    body_long_total = float(arr_bl[body_long_trail - 2 : start_idx - 2].sum())
+    O = ca.open
+    C = ca.close
+
+    for i in range(start_idx, len(out)):
+        if (
+            # 1st white
+            ca.color[i - 2] == 1
+            # 2nd white
+            and ca.color[i - 1] == 1
+            # 3rd white
+            and ca.color[i] == 1
+            # Consecutive higher closes
+            and C[i] > C[i - 1]
+            and C[i - 1] > C[i - 2]
+            # 2nd opens within/near 1st real body
+            and O[i - 1] > O[i - 2]
+            and O[i - 1] <= C[i - 2] + AVG_FACTOR[CandleSetting.Near] * near_total_2
+            # 3rd opens within/near 2nd real body
+            and O[i] > O[i - 1]
+            and O[i] <= C[i - 1] + AVG_FACTOR[CandleSetting.Near] * near_total_1
+            # 1st: long real body
+            and ca.real_body[i - 2]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            # 1st: short upper shadow
+            and ca.upper_shadow[i - 2]
+            < AVG_FACTOR[CandleSetting.ShadowShort] * ss_total_2
+            # Signs of weakening (any of 4 sub-conditions)
+            and (
+                # Sub-condition 1: 2nd far smaller than 1st AND
+                # 3rd not longer than 2nd
+                (
+                    ca.real_body[i - 1]
+                    < ca.real_body[i - 2] - AVG_FACTOR[CandleSetting.Far] * far_total_2
+                    and ca.real_body[i]
+                    < ca.real_body[i - 1]
+                    + AVG_FACTOR[CandleSetting.Near] * near_total_1
+                )
+                # Sub-condition 2: 3rd far smaller than 2nd
+                or (
+                    ca.real_body[i]
+                    < ca.real_body[i - 1] - AVG_FACTOR[CandleSetting.Far] * far_total_1
+                )
+                # Sub-condition 3: progressively smaller bodies AND
+                # (3rd or 2nd has non-short upper shadow)
+                or (
+                    ca.real_body[i] < ca.real_body[i - 1]
+                    and ca.real_body[i - 1] < ca.real_body[i - 2]
+                    and (
+                        ca.upper_shadow[i]
+                        > AVG_FACTOR[CandleSetting.ShadowShort] * ss_total_0
+                        or ca.upper_shadow[i - 1]
+                        > AVG_FACTOR[CandleSetting.ShadowShort] * ss_total_1
+                    )
+                )
+                # Sub-condition 4: 3rd smaller than 2nd AND
+                # 3rd has long upper shadow
+                or (
+                    ca.real_body[i] < ca.real_body[i - 1]
+                    and ca.upper_shadow[i]
+                    > AVG_FACTOR[CandleSetting.ShadowLong] * arr_sl[i]
+                )
+            )
+        ):
+            out[i] = -100  # Always bearish
+
+        # Update ShadowShort totals [2], [1], [0]
+        ss_total_2 += arr_ss[i - 2] - arr_ss[shadow_short_trail - 2]
+        ss_total_1 += arr_ss[i - 1] - arr_ss[shadow_short_trail - 1]
+        ss_total_0 += arr_ss[i] - arr_ss[shadow_short_trail]
+
+        # Update ShadowLong totals [1], [0]
+        sl_total_1 += arr_sl[i - 1] - arr_sl[shadow_long_trail - 1]
+        sl_total_0 += arr_sl[i] - arr_sl[shadow_long_trail]
+
+        # Update Far and Near totals [2], [1]
+        far_total_2 += arr_fr[i - 2] - arr_fr[far_trail - 2]
+        far_total_1 += arr_fr[i - 1] - arr_fr[far_trail - 1]
+        near_total_2 += arr_nr[i - 2] - arr_nr[near_trail - 2]
+        near_total_1 += arr_nr[i - 1] - arr_nr[near_trail - 1]
+
+        # Update BodyLong total (applied to i-2)
+        body_long_total += arr_bl[i - 2] - arr_bl[body_long_trail - 2]
+
+        shadow_short_trail += 1
+        shadow_long_trail += 1
+        near_trail += 1
+        far_trail += 1
+        body_long_trail += 1
+
+
+def cdl_advanceblock(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Advance Block
+
+    A 3-candle bearish reversal pattern. Three consecutive white candles
+    with consecutively higher closes, each opening within or near the
+    previous real body. The first has a long body with a short upper
+    shadow. Signs of weakening appear: progressively smaller real bodies,
+    relatively long upper shadows, or the second/third candle being far
+    shorter than the prior one.
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        scalar: Multiplier for output values. Default: 100.
+        offset: Number of periods to shift the result.
+
+    Returns:
+        A Series with -100 (bearish) / 0, or None.
+
+    Example:
+        >>> result = cdl_advanceblock(df.open, df.high, df.low, df.close)
+    """
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_ADVANCEBLOCK",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_belthold.py
+++ b/pandas_ta_classic/candles/cdl_belthold.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    shadow_vs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    lookback = max(body_long_period, shadow_vs_period)
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+
+    body_long_trail = start_idx - body_long_period
+    shadow_vs_trail = start_idx - shadow_vs_period
+    body_long_total = float(arr_bl[body_long_trail:start_idx].sum())
+    shadow_vs_total = float(arr_svs[shadow_vs_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if ca.real_body[i] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total and (
+            (
+                ca.color[i] == 1
+                and ca.lower_shadow[i]
+                < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+            )
+            or (
+                ca.color[i] == -1
+                and ca.upper_shadow[i]
+                < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+            )
+        ):
+            out[i] = ca.color[i] * 100
+
+        # Update trailing windows
+        body_long_total += arr_bl[i] - arr_bl[body_long_trail]
+        shadow_vs_total += arr_svs[i] - arr_svs[shadow_vs_trail]
+        body_long_trail += 1
+        shadow_vs_trail += 1
+
+
+def cdl_belthold(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Belthold"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_BELTHOLD",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_breakaway.py
+++ b/pandas_ta_classic/candles/cdl_breakaway.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Lookback: TA_CANDLEAVGPERIOD(BodyLong) + 4
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    lookback = body_long_period + 4
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    # Trailing index for BodyLong setting applied to i-4
+    body_long_trail = start_idx - body_long_period
+
+    # Seed BodyLong total: sum candle_range(BodyLong, i-4)
+    # for i from body_long_trail to start_idx-1
+    body_long_total = float(arr_bl[body_long_trail - 4 : start_idx - 4].sum())
+    O = ca.open
+    H = ca.high
+    L = ca.low
+    C = ca.close
+
+    for i in range(start_idx, len(out)):
+        if (
+            # 1st: long body
+            ca.real_body[i - 4] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            # 1st, 2nd, 4th same color; 5th opposite
+            and ca.color[i - 4] == ca.color[i - 3]
+            and ca.color[i - 3] == ca.color[i - 1]
+            and ca.color[i - 1] == -ca.color[i]
+            and (
+                (
+                    # When 1st is black:
+                    ca.color[i - 4] == -1
+                    # 2nd gaps down
+                    and body_hi[i - 3] < body_lo[i - 4]
+                    # 3rd has lower high and low than 2nd
+                    and H[i - 2] < H[i - 3]
+                    and L[i - 2] < L[i - 3]
+                    # 4th has lower high and low than 3rd
+                    and H[i - 1] < H[i - 2]
+                    and L[i - 1] < L[i - 2]
+                    # 5th closes inside the gap
+                    and C[i] > O[i - 3]
+                    and C[i] < C[i - 4]
+                )
+                or (
+                    # When 1st is white:
+                    ca.color[i - 4] == 1
+                    # 2nd gaps up
+                    and body_lo[i - 3] > body_hi[i - 4]
+                    # 3rd has higher high and low than 2nd
+                    and H[i - 2] > H[i - 3]
+                    and L[i - 2] > L[i - 3]
+                    # 4th has higher high and low than 3rd
+                    and H[i - 1] > H[i - 2]
+                    and L[i - 1] > L[i - 2]
+                    # 5th closes inside the gap
+                    and C[i] < O[i - 3]
+                    and C[i] > C[i - 4]
+                )
+            )
+        ):
+            out[i] = ca.color[i] * 100
+
+        # Update: add current, subtract trailing (both reference i-4)
+        body_long_total += arr_bl[i - 4] - arr_bl[body_long_trail - 4]
+        body_long_trail += 1
+
+
+def cdl_breakaway(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Breakaway
+
+    A 5-candle reversal pattern. Bullish breakaway begins with a long
+    bearish candle, followed by a gap-down and two more bearish candles
+    with successively lower highs/lows, then a bullish candle that
+    closes inside the initial gap. Bearish breakaway is the mirror.
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        scalar: Multiplier for output values. Default: 100.
+        offset: Number of periods to shift the result.
+
+    Returns:
+        A Series with +100 (bullish) / -100 (bearish) / 0, or None.
+
+    Example:
+        >>> result = cdl_breakaway(df.open, df.high, df.low, df.close)
+    """
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_BREAKAWAY",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_closingmarubozu.py
+++ b/pandas_ta_classic/candles/cdl_closingmarubozu.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    shadow_vs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    lookback = max(body_long_period, shadow_vs_period)
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+
+    body_long_trail = start_idx - body_long_period
+    shadow_vs_trail = start_idx - shadow_vs_period
+    body_long_total = float(arr_bl[body_long_trail:start_idx].sum())
+    shadow_vs_total = float(arr_svs[shadow_vs_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if ca.real_body[i] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total and (
+            (
+                ca.color[i] == 1
+                and ca.upper_shadow[i]
+                < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+            )
+            or (
+                ca.color[i] == -1
+                and ca.lower_shadow[i]
+                < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+            )
+        ):
+            out[i] = ca.color[i] * 100
+
+        # Update trailing windows
+        body_long_total += arr_bl[i] - arr_bl[body_long_trail]
+        shadow_vs_total += arr_svs[i] - arr_svs[shadow_vs_trail]
+        body_long_trail += 1
+        shadow_vs_trail += 1
+
+
+def cdl_closingmarubozu(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Closingmarubozu"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_CLOSINGMARUBOZU",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_concealbabyswall.py
+++ b/pandas_ta_classic/candles/cdl_concealbabyswall.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Lookback: TA_CANDLEAVGPERIOD(ShadowVeryShort) + 3
+    svs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    lookback = svs_period + 3
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    svs_trail = start_idx - svs_period
+
+    # Seed totals for candles at i-3, i-2, i-1
+    svs_total = [0.0, 0.0, 0.0, 0.0]  # indexed [0..3], use [1],[2],[3]
+    for j in range(svs_trail, start_idx):
+        svs_total[3] += arr_svs[j - 3]
+        svs_total[2] += arr_svs[j - 2]
+        svs_total[1] += arr_svs[j - 1]
+
+    H = ca.high
+    L = ca.low
+    C = ca.close
+
+    for i in range(start_idx, len(out)):
+        if (
+            # All four candles are black
+            ca.color[i - 3] == -1
+            and ca.color[i - 2] == -1
+            and ca.color[i - 1] == -1
+            and ca.color[i] == -1
+            # 1st: marubozu (very short shadows)
+            and ca.lower_shadow[i - 3]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total[3]
+            and ca.upper_shadow[i - 3]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total[3]
+            # 2nd: marubozu (very short shadows)
+            and ca.lower_shadow[i - 2]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total[2]
+            and ca.upper_shadow[i - 2]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total[2]
+            # 3rd: opens gapping down
+            and body_hi[i - 1] < body_lo[i - 2]
+            # 3rd: HAS an upper shadow
+            and ca.upper_shadow[i - 1]
+            > AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total[1]
+            # 3rd upper shadow extends into the prior body
+            and H[i - 1] > C[i - 2]
+            # 4th: engulfs the 3rd including the shadows
+            and H[i] > H[i - 1]
+            and L[i] < L[i - 1]
+        ):
+            out[i] = 100  # Always bullish
+
+        # Update totals
+        for k in range(3, 0, -1):
+            svs_total[k] += arr_svs[i - k] - arr_svs[svs_trail - k]
+        svs_trail += 1
+
+
+def cdl_concealbabyswall(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Concealing Baby Swallow
+
+    A 4-candle bullish reversal pattern. All four candles are bearish.
+    The first two are marubozu (very short shadows). The third opens
+    gapping down but has an upper shadow that reaches into the second
+    candle's body. The fourth completely engulfs the third (including
+    shadows).
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        scalar: Multiplier for output values. Default: 100.
+        offset: Number of periods to shift the result.
+
+    Returns:
+        A Series with +100 (bullish) / 0, or None.
+
+    Example:
+        >>> result = cdl_concealbabyswall(df.open, df.high, df.low, df.close)
+    """
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_CONCEALBABYSWALL",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_counterattack.py
+++ b/pandas_ta_classic/candles/cdl_counterattack.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Lookback: max(Equal, BodyLong) + 1
+    equal_period = candle_avg_period(CandleSetting.Equal)
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    lookback = max(equal_period, body_long_period) + 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_eq = ca._ranges[CandleSetting.Equal]
+
+    equal_trail = start_idx - equal_period
+    body_long_trail = start_idx - body_long_period
+
+    equal_total = 0.0
+    i = equal_trail
+    while i < start_idx:
+        equal_total += arr_eq[i - 1]
+        i += 1
+
+    body_long_total_1 = 0.0
+    body_long_total_0 = 0.0
+    i = body_long_trail
+    while i < start_idx:
+        body_long_total_1 += arr_bl[i - 1]
+        body_long_total_0 += arr_bl[i]
+        i += 1
+
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 1] == -ca.color[i]  # opposite candles
+            and ca.real_body[i - 1]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total_1  # 1st long
+            and ca.real_body[i]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total_0  # 2nd long
+            and ca.close[i]
+            <= ca.close[i - 1]
+            + AVG_FACTOR[CandleSetting.Equal] * equal_total  # equal closes
+            and ca.close[i]
+            >= ca.close[i - 1] - AVG_FACTOR[CandleSetting.Equal] * equal_total
+        ):
+            out[i] = ca.color[i] * 100
+
+        equal_total += arr_eq[i - 1] - arr_eq[equal_trail - 1]
+        for totIdx in range(1, -1, -1):
+            body_long_total_1 if totIdx == 1 else body_long_total_0  # noqa
+        body_long_total_1 += arr_bl[i - 1] - arr_bl[body_long_trail - 1]
+        body_long_total_0 += arr_bl[i] - arr_bl[body_long_trail]
+        equal_trail += 1
+        body_long_trail += 1
+
+
+def cdl_counterattack(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Counterattack"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_COUNTERATTACK",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_darkcloudcover.py
+++ b/pandas_ta_classic/candles/cdl_darkcloudcover.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    penetration = kwargs.get("penetration", 0.5)
+    # Lookback: TA_CANDLEAVGPERIOD(BodyLong) + 1
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    lookback = body_long_period + 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+
+    body_long_trail = start_idx - body_long_period
+
+    body_long_total = 0.0
+    i = body_long_trail
+    while i < start_idx:
+        body_long_total += arr_bl[i - 1]
+        i += 1
+
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 1] == 1  # 1st: white
+            and ca.real_body[i - 1]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total  # long
+            and ca.color[i] == -1  # 2nd: black
+            and ca.open[i] > ca.high[i - 1]  # open above prior high
+            and ca.close[i] > ca.open[i - 1]  # close within prior body
+            and ca.close[i] < ca.close[i - 1] - ca.real_body[i - 1] * penetration
+        ):
+            out[i] = -100
+
+        body_long_total += arr_bl[i - 1] - arr_bl[body_long_trail - 1]
+        body_long_trail += 1
+
+
+def cdl_darkcloudcover(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    penetration: Optional[float] = None,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Dark Cloud Cover"""
+    if penetration is None:
+        penetration = 0.5
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_DARKCLOUDCOVER",
+        scalar=scalar,
+        offset=offset,
+        penetration=penetration,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_dojistar.py
+++ b/pandas_ta_classic/candles/cdl_dojistar.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    body_doji_period = candle_avg_period(CandleSetting.BodyDoji)
+    lookback = max(body_long_period, body_doji_period)
+    lookback += 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bd = ca._ranges[CandleSetting.BodyDoji]
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    body_long_trail = start_idx + (-1) - body_long_period
+    body_doji_trail = start_idx - body_doji_period
+    body_long_total = float(arr_bl[body_long_trail : start_idx + (-1)].sum())
+    body_doji_total = float(arr_bd[body_doji_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i - 1] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.real_body[i] <= AVG_FACTOR[CandleSetting.BodyDoji] * body_doji_total
+            and (
+                (ca.color[i - 1] == 1 and body_lo[i] > body_hi[i - 1])
+                or (ca.color[i - 1] == -1 and body_hi[i] < body_lo[i - 1])
+            )
+        ):
+            out[i] = -ca.color[i - 1] * 100
+
+        # Update trailing windows
+        body_long_total += arr_bl[i + (-1)] - arr_bl[body_long_trail]
+        body_doji_total += arr_bd[i] - arr_bd[body_doji_trail]
+        body_long_trail += 1
+        body_doji_trail += 1
+
+
+def cdl_dojistar(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Dojistar"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_DOJISTAR",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_dragonflydoji.py
+++ b/pandas_ta_classic/candles/cdl_dragonflydoji.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_doji_period = candle_avg_period(CandleSetting.BodyDoji)
+    shadow_vs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    lookback = max(body_doji_period, shadow_vs_period)
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bd = ca._ranges[CandleSetting.BodyDoji]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+
+    body_doji_trail = start_idx - body_doji_period
+    shadow_vs_trail = start_idx - shadow_vs_period
+    body_doji_total = float(arr_bd[body_doji_trail:start_idx].sum())
+    shadow_vs_total = float(arr_svs[shadow_vs_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i] <= AVG_FACTOR[CandleSetting.BodyDoji] * body_doji_total
+            and ca.upper_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+            and ca.lower_shadow[i]
+            > AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+        ):
+            out[i] = 100
+
+        # Update trailing windows
+        body_doji_total += arr_bd[i] - arr_bd[body_doji_trail]
+        shadow_vs_total += arr_svs[i] - arr_svs[shadow_vs_trail]
+        body_doji_trail += 1
+        shadow_vs_trail += 1
+
+
+def cdl_dragonflydoji(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Dragonflydoji"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_DRAGONFLYDOJI",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_engulfing.py
+++ b/pandas_ta_classic/candles/cdl_engulfing.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    CandleArrays,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Lookback: 2 (no candle settings needed)
+    start_idx = 2
+    if start_idx >= len(out):
+        return
+
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i] == 1
+            and ca.color[i - 1] == -1  # white engulfs black
+            and (
+                (ca.close[i] >= ca.open[i - 1] and ca.open[i] < ca.close[i - 1])
+                or (ca.close[i] > ca.open[i - 1] and ca.open[i] <= ca.close[i - 1])
+            )
+        ) or (
+            ca.color[i] == -1
+            and ca.color[i - 1] == 1  # black engulfs white
+            and (
+                (ca.open[i] >= ca.close[i - 1] and ca.close[i] < ca.open[i - 1])
+                or (ca.open[i] > ca.close[i - 1] and ca.close[i] <= ca.open[i - 1])
+            )
+        ):
+            if ca.open[i] != ca.close[i - 1] and ca.close[i] != ca.open[i - 1]:
+                out[i] = ca.color[i] * 100
+            else:
+                out[i] = ca.color[i] * 80
+
+
+def cdl_engulfing(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Engulfing"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_ENGULFING",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_eveningdojistar.py
+++ b/pandas_ta_classic/candles/cdl_eveningdojistar.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    penetration = kwargs.get("penetration", 0.3)
+
+    # Lookback: max(BodyDoji, BodyLong, BodyShort) + 2
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    body_doji_period = candle_avg_period(CandleSetting.BodyDoji)
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    lookback = max(body_doji_period, body_long_period, body_short_period) + 2
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bd = ca._ranges[CandleSetting.BodyDoji]
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    # Trailing indices
+    # BodyLong at offset i-2: trail = startIdx - 2 - period
+    body_long_trail = start_idx - 2 - body_long_period
+    # BodyDoji at offset i-1: trail = startIdx - 1 - period
+    body_doji_trail = start_idx - 1 - body_doji_period
+    # BodyShort at offset i: trail = startIdx - period
+    body_short_trail = start_idx - body_short_period
+
+    # Seed totals
+    body_long_total = float(arr_bl[body_long_trail : start_idx - 2].sum())
+    body_doji_total = float(arr_bd[body_doji_trail : start_idx - 1].sum())
+    body_short_total = float(arr_bs[body_short_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            # 1st: long white
+            ca.real_body[i - 2] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.color[i - 2] == 1
+            # 2nd: doji gapping up
+            and ca.real_body[i - 1]
+            <= AVG_FACTOR[CandleSetting.BodyDoji] * body_doji_total
+            and body_lo[i - 1] > body_hi[i - 2]
+            # 3rd: longer than short, black, closing well within 1st rb
+            and ca.real_body[i] > AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            and ca.color[i] == -1
+            and ca.close[i] < ca.close[i - 2] - ca.real_body[i - 2] * penetration
+        ):
+            out[i] = -100
+
+        # Update trailing windows
+        body_long_total += arr_bl[i - 2] - arr_bl[body_long_trail]
+        body_doji_total += arr_bd[i - 1] - arr_bd[body_doji_trail]
+        body_short_total += arr_bs[i] - arr_bs[body_short_trail]
+        body_long_trail += 1
+        body_doji_trail += 1
+        body_short_trail += 1
+
+
+def cdl_eveningdojistar(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    penetration: Optional[float] = None,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Evening Doji Star
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        penetration: Percentage of penetration within the first candle's
+            real body. Default: 0.3
+        scalar: Multiplier for output values. Default: 100.
+        offset: How many periods to shift the result.
+
+    Returns:
+        A pandas Series with -100 (bearish) or 0.
+    """
+    if penetration is None:
+        penetration = 0.3
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_EVENINGDOJISTAR",
+        scalar=scalar,
+        offset=offset,
+        penetration=penetration,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_eveningstar.py
+++ b/pandas_ta_classic/candles/cdl_eveningstar.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    penetration = kwargs.get("penetration", 0.3)
+
+    # Lookback: max(BodyShort, BodyLong) + 2
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    lookback = max(body_short_period, body_long_period) + 2
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    # Trailing indices
+    # BodyLong at offset i-2: trail = startIdx - 2 - period
+    body_long_trail = start_idx - 2 - body_long_period
+    # BodyShort at offset i-1: trail = startIdx - 1 - period
+    # Both BodyShort totals share the same trailing index
+    body_short_trail = start_idx - 1 - body_short_period
+
+    # Seed totals
+    body_long_total = float(arr_bl[body_long_trail : start_idx - 2].sum())
+    # BodyShortPeriodTotal tracks BodyShort at i-1
+    # BodyShortPeriodTotal2 tracks BodyShort at i
+    body_short_total = float(arr_bs[body_short_trail : start_idx - 1].sum())
+    body_short_total2 = float(arr_bs[body_short_trail + 1 : start_idx - 1 + 1].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            # 1st: long white
+            ca.real_body[i - 2] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.color[i - 2] == 1
+            # 2nd: short, gapping up
+            and ca.real_body[i - 1]
+            <= AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            and body_lo[i - 1] > body_hi[i - 2]
+            # 3rd: longer than short, black, closing well within 1st rb
+            and ca.real_body[i]
+            > AVG_FACTOR[CandleSetting.BodyShort] * body_short_total2
+            and ca.color[i] == -1
+            and ca.close[i] < ca.close[i - 2] - ca.real_body[i - 2] * penetration
+        ):
+            out[i] = -100
+
+        # Update trailing windows
+        body_long_total += arr_bl[i - 2] - arr_bl[body_long_trail]
+        body_short_total += arr_bs[i - 1] - arr_bs[body_short_trail]
+        body_short_total2 += arr_bs[i] - arr_bs[body_short_trail + 1]
+        body_long_trail += 1
+        body_short_trail += 1
+
+
+def cdl_eveningstar(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    penetration: Optional[float] = None,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Evening Star
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        penetration: Percentage of penetration within the first candle's
+            real body. Default: 0.3
+        scalar: Multiplier for output values. Default: 100.
+        offset: How many periods to shift the result.
+
+    Returns:
+        A pandas Series with -100 (bearish) or 0.
+    """
+    if penetration is None:
+        penetration = 0.3
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_EVENINGSTAR",
+        scalar=scalar,
+        offset=offset,
+        penetration=penetration,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_gapsidesidewhite.py
+++ b/pandas_ta_classic/candles/cdl_gapsidesidewhite.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Lookback: max(Near, Equal) + 2
+    near_period = candle_avg_period(CandleSetting.Near)
+    equal_period = candle_avg_period(CandleSetting.Equal)
+    lookback = max(near_period, equal_period) + 2
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_eq = ca._ranges[CandleSetting.Equal]
+    arr_nr = ca._ranges[CandleSetting.Near]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    near_trail = start_idx - near_period
+    equal_trail = start_idx - equal_period
+
+    near_total = 0.0
+    i = near_trail
+    while i < start_idx:
+        near_total += arr_nr[i - 1]
+        i += 1
+
+    equal_total = 0.0
+    i = equal_trail
+    while i < start_idx:
+        equal_total += arr_eq[i - 1]
+        i += 1
+
+    for i in range(start_idx, len(out)):
+        if (
+            (
+                (body_lo[i - 1] > body_hi[i - 2] and body_lo[i] > body_hi[i - 2])
+                or (body_hi[i - 1] < body_lo[i - 2] and body_hi[i] < body_lo[i - 2])
+            )
+            and ca.color[i - 1] == 1  # 2nd: white
+            and ca.color[i] == 1  # 3rd: white
+            and ca.real_body[i]
+            >= ca.real_body[i - 1]
+            - AVG_FACTOR[CandleSetting.Near] * near_total  # same size
+            and ca.real_body[i]
+            <= ca.real_body[i - 1] + AVG_FACTOR[CandleSetting.Near] * near_total
+            and ca.open[i]
+            >= ca.open[i - 1]
+            - AVG_FACTOR[CandleSetting.Equal] * equal_total  # same open
+            and ca.open[i]
+            <= ca.open[i - 1] + AVG_FACTOR[CandleSetting.Equal] * equal_total
+        ):
+            out[i] = 100 if body_lo[i - 1] > body_hi[i - 2] else -100
+
+        near_total += arr_nr[i - 1] - arr_nr[near_trail - 1]
+        equal_total += arr_eq[i - 1] - arr_eq[equal_trail - 1]
+        near_trail += 1
+        equal_trail += 1
+
+
+def cdl_gapsidesidewhite(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Gap Side-by-Side White Lines"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_GAPSIDESIDEWHITE",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_gravestonedoji.py
+++ b/pandas_ta_classic/candles/cdl_gravestonedoji.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_doji_period = candle_avg_period(CandleSetting.BodyDoji)
+    shadow_vs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    lookback = max(body_doji_period, shadow_vs_period)
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bd = ca._ranges[CandleSetting.BodyDoji]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+
+    body_doji_trail = start_idx - body_doji_period
+    shadow_vs_trail = start_idx - shadow_vs_period
+    body_doji_total = float(arr_bd[body_doji_trail:start_idx].sum())
+    shadow_vs_total = float(arr_svs[shadow_vs_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i] <= AVG_FACTOR[CandleSetting.BodyDoji] * body_doji_total
+            and ca.lower_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+            and ca.upper_shadow[i]
+            > AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+        ):
+            out[i] = 100
+
+        # Update trailing windows
+        body_doji_total += arr_bd[i] - arr_bd[body_doji_trail]
+        shadow_vs_total += arr_svs[i] - arr_svs[shadow_vs_trail]
+        body_doji_trail += 1
+        shadow_vs_trail += 1
+
+
+def cdl_gravestonedoji(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Gravestonedoji"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_GRAVESTONEDOJI",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_hammer.py
+++ b/pandas_ta_classic/candles/cdl_hammer.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_period = candle_avg_period(CandleSetting.BodyShort)
+    shadow_long_period = candle_avg_period(CandleSetting.ShadowLong)  # 0
+    shadow_vs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    near_period = candle_avg_period(CandleSetting.Near)
+
+    # Lookback: max of all periods + 1 (extra bar for i-1 reference)
+    lookback = max(body_period, shadow_long_period, shadow_vs_period, near_period) + 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    arr_nr = ca._ranges[CandleSetting.Near]
+    arr_sl = ca._ranges[CandleSetting.ShadowLong]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    # Trailing indices
+    body_trail = start_idx - body_period
+    shadow_long_trail = start_idx - shadow_long_period
+    shadow_vs_trail = start_idx - shadow_vs_period
+    near_trail = start_idx - 1 - near_period  # Near uses i-1
+
+    # Seed totals
+    body_total = float(arr_bs[body_trail:start_idx].sum())
+    shadow_long_total = float(arr_sl[shadow_long_trail:start_idx].sum())
+    shadow_vs_total = float(arr_svs[shadow_vs_trail:start_idx].sum())
+    near_total = float(arr_nr[near_trail : start_idx - 1].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i] < AVG_FACTOR[CandleSetting.BodyShort] * body_total
+            and ca.lower_shadow[i] > AVG_FACTOR[CandleSetting.ShadowLong] * arr_sl[i]
+            and ca.upper_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+            and (
+                body_lo[i]
+                <= ca.low[i - 1] + AVG_FACTOR[CandleSetting.Near] * near_total
+            )
+        ):
+            out[i] = 100
+
+        # Update trailing windows AFTER pattern check
+        body_total += arr_bs[i] - arr_bs[body_trail]
+        shadow_long_total += arr_sl[i] - arr_sl[shadow_long_trail]
+        shadow_vs_total += arr_svs[i] - arr_svs[shadow_vs_trail]
+        near_total += arr_nr[i - 1] - arr_nr[near_trail]
+
+        body_trail += 1
+        shadow_long_trail += 1
+        shadow_vs_trail += 1
+        near_trail += 1
+
+
+def cdl_hammer(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Hammer"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_HAMMER",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_hangingman.py
+++ b/pandas_ta_classic/candles/cdl_hangingman.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    shadow_long_period = candle_avg_period(CandleSetting.ShadowLong)
+    shadow_vs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    near_period = candle_avg_period(CandleSetting.Near)
+    lookback = max(body_short_period, shadow_long_period, shadow_vs_period, near_period)
+    lookback += 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    arr_nr = ca._ranges[CandleSetting.Near]
+    arr_sl = ca._ranges[CandleSetting.ShadowLong]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    body_short_trail = start_idx - body_short_period
+    shadow_long_trail = start_idx - shadow_long_period
+    shadow_vs_trail = start_idx - shadow_vs_period
+    near_trail = start_idx + (-1) - near_period
+    body_short_total = float(arr_bs[body_short_trail:start_idx].sum())
+    shadow_long_total = float(arr_sl[shadow_long_trail:start_idx].sum())
+    shadow_vs_total = float(arr_svs[shadow_vs_trail:start_idx].sum())
+    near_total = float(arr_nr[near_trail : start_idx + (-1)].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i] < AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            and ca.lower_shadow[i] > AVG_FACTOR[CandleSetting.ShadowLong] * arr_sl[i]
+            and ca.upper_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+            and body_lo[i]
+            >= ca.high[i - 1] - AVG_FACTOR[CandleSetting.Near] * near_total
+        ):
+            out[i] = -100
+
+        # Update trailing windows
+        body_short_total += arr_bs[i] - arr_bs[body_short_trail]
+        shadow_long_total += arr_sl[i] - arr_sl[shadow_long_trail]
+        shadow_vs_total += arr_svs[i] - arr_svs[shadow_vs_trail]
+        near_total += arr_nr[i + (-1)] - arr_nr[near_trail]
+        body_short_trail += 1
+        shadow_long_trail += 1
+        shadow_vs_trail += 1
+        near_trail += 1
+
+
+def cdl_hangingman(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Hangingman"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_HANGINGMAN",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_harami.py
+++ b/pandas_ta_classic/candles/cdl_harami.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Lookback: max(BodyShort, BodyLong) + 1
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    lookback = max(body_short_period, body_long_period) + 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    body_long_trail = start_idx - 1 - body_long_period
+    body_short_trail = start_idx - body_short_period
+    body_long_total = float(arr_bl[body_long_trail : start_idx - 1].sum())
+    body_short_total = float(arr_bs[body_short_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i - 1] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.real_body[i]  # 1st: long
+            <= AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+        ):  # 2nd: short
+            hi_i = body_hi[i]
+            lo_i = body_lo[i]
+            hi_p = body_hi[i - 1]
+            lo_p = body_lo[i - 1]
+            if hi_i < hi_p and lo_i > lo_p:
+                out[i] = -ca.color[i - 1] * 100
+            elif hi_i <= hi_p and lo_i >= lo_p:
+                out[i] = -ca.color[i - 1] * 80
+
+        body_long_total += arr_bl[i - 1] - arr_bl[body_long_trail]
+        body_short_total += arr_bs[i] - arr_bs[body_short_trail]
+        body_long_trail += 1
+        body_short_trail += 1
+
+
+def cdl_harami(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Harami"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_HARAMI",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_haramicross.py
+++ b/pandas_ta_classic/candles/cdl_haramicross.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    body_doji_period = candle_avg_period(CandleSetting.BodyDoji)
+    lookback = max(body_long_period, body_doji_period) + 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bd = ca._ranges[CandleSetting.BodyDoji]
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    body_long_trail = start_idx - 1 - body_long_period
+    body_doji_trail = start_idx - body_doji_period
+    body_long_total = float(arr_bl[body_long_trail : start_idx - 1].sum())
+    body_doji_total = float(arr_bd[body_doji_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i - 1] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.real_body[i] <= AVG_FACTOR[CandleSetting.BodyDoji] * body_doji_total
+        ):
+            if (
+                body_hi[i] < max(ca.close[i - 1], ca.open[i - 1])
+                and body_lo[i] > body_lo[i - 1]
+            ):
+                out[i] = -ca.color[i - 1] * 100
+            elif (
+                body_hi[i] <= max(ca.close[i - 1], ca.open[i - 1])
+                and body_lo[i] >= body_lo[i - 1]
+            ):
+                out[i] = -ca.color[i - 1] * 80
+
+        body_long_total += arr_bl[i - 1] - arr_bl[body_long_trail]
+        body_doji_total += arr_bd[i] - arr_bd[body_doji_trail]
+        body_long_trail += 1
+        body_doji_trail += 1
+
+
+def cdl_haramicross(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Haramicross"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_HARAMICROSS",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_highwave.py
+++ b/pandas_ta_classic/candles/cdl_highwave.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    shadow_vl_period = candle_avg_period(CandleSetting.ShadowVeryLong)
+    lookback = max(body_short_period, shadow_vl_period)
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    arr_svl = ca._ranges[CandleSetting.ShadowVeryLong]
+
+    body_short_trail = start_idx - body_short_period
+    shadow_vl_trail = start_idx - shadow_vl_period
+    body_short_total = float(arr_bs[body_short_trail:start_idx].sum())
+    shadow_vl_total = float(arr_svl[shadow_vl_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i] < AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            and ca.upper_shadow[i]
+            > AVG_FACTOR[CandleSetting.ShadowVeryLong] * arr_svl[i]
+            and ca.lower_shadow[i]
+            > AVG_FACTOR[CandleSetting.ShadowVeryLong] * arr_svl[i]
+        ):
+            out[i] = ca.color[i] * 100
+
+        # Update trailing windows
+        body_short_total += arr_bs[i] - arr_bs[body_short_trail]
+        shadow_vl_total += arr_svl[i] - arr_svl[shadow_vl_trail]
+        body_short_trail += 1
+        shadow_vl_trail += 1
+
+
+def cdl_highwave(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Highwave"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_HIGHWAVE",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_hikkake.py
+++ b/pandas_ta_classic/candles/cdl_hikkake.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    CandleArrays,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Lookback = 5  (no candle settings used)
+    lookback = 5
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    H = ca.high
+    L = ca.low
+    C = ca.close
+
+    pattern_idx = 0
+    pattern_result = 0
+
+    # Warm-up: scan the 3 bars before start_idx to initialize state
+    # (i runs from start_idx-3 to start_idx-1)
+    for i in range(start_idx - 3, start_idx):
+        if (
+            H[i - 1] < H[i - 2]
+            and L[i - 1] > L[i - 2]
+            and (
+                (H[i] < H[i - 1] and L[i] < L[i - 1])
+                or (H[i] > H[i - 1] and L[i] > L[i - 1])
+            )
+        ):
+            pattern_result = 100 * (1 if H[i] < H[i - 1] else -1)
+            pattern_idx = i
+        else:
+            # Search for confirmation
+            if i <= pattern_idx + 3 and (
+                (pattern_result > 0 and C[i] > H[pattern_idx - 1])
+                or (pattern_result < 0 and C[i] < L[pattern_idx - 1])
+            ):
+                pattern_idx = 0
+
+    # Main loop
+    for i in range(start_idx, len(out)):
+        if (
+            # 1st + 2nd: inside bar (lower high, higher low)
+            H[i - 1] < H[i - 2]
+            and L[i - 1] > L[i - 2]
+            and (
+                # (bull) 3rd: lower high and lower low
+                (H[i] < H[i - 1] and L[i] < L[i - 1])
+                or
+                # (bear) 3rd: higher high and higher low
+                (H[i] > H[i - 1] and L[i] > L[i - 1])
+            )
+        ):
+            pattern_result = 100 * (1 if H[i] < H[i - 1] else -1)
+            pattern_idx = i
+            out[i] = pattern_result
+        elif i <= pattern_idx + 3 and (
+            (pattern_result > 0 and C[i] > H[pattern_idx - 1])
+            or (pattern_result < 0 and C[i] < L[pattern_idx - 1])
+        ):
+            out[i] = pattern_result + 100 * (1 if pattern_result > 0 else -1)
+            pattern_idx = 0
+
+
+def cdl_hikkake(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Hikkake
+
+    A stateful pattern that detects an inside bar (bar 2 has lower high
+    and higher low than bar 1) followed by a breakout bar (bar 3) that
+    exceeds the inside bar's range. Confirmation occurs within the next
+    3 bars when price closes beyond the inside bar's high/low.
+
+    The pattern bar outputs +/-100 and the confirmation bar outputs
+    +/-200.
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        scalar: Multiplier for output values. Default: 100.
+        offset: Number of periods to shift the result.
+
+    Returns:
+        A Series with pattern signals, or None.
+
+    Example:
+        >>> result = cdl_hikkake(df.open, df.high, df.low, df.close)
+    """
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_HIKKAKE",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_hikkakemod.py
+++ b/pandas_ta_classic/candles/cdl_hikkakemod.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Lookback: max(1, TA_CANDLEAVGPERIOD(Near)) + 5
+    near_period = candle_avg_period(CandleSetting.Near)
+    lookback = max(1, near_period) + 5
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_nr = ca._ranges[CandleSetting.Near]
+
+    H = ca.high
+    L = ca.low
+    C = ca.close
+
+    # Near trailing: seeds for the Near setting applied at i-2
+    # NearTrailingIdx = startIdx - 3 - near_period
+    near_trail = start_idx - 3 - near_period
+
+    # Seed Near total
+    near_total = 0.0
+    j = near_trail
+    while j < start_idx - 3:
+        near_total += arr_nr[j - 2]
+        j += 1
+
+    pattern_idx = 0
+    pattern_result = 0
+
+    # Warm-up: scan the 3 bars before start_idx
+    for i in range(start_idx - 3, start_idx):
+        if (
+            # 2nd: lower high and higher low than 1st
+            H[i - 2] < H[i - 3]
+            and L[i - 2] > L[i - 3]
+            # 3rd: lower high and higher low than 2nd
+            and H[i - 1] < H[i - 2]
+            and L[i - 1] > L[i - 2]
+            and (
+                (
+                    # (bull) 4th: lower high and lower low
+                    H[i] < H[i - 1]
+                    and L[i] < L[i - 1]
+                    # (bull) 2nd: close near the low
+                    and C[i - 2]
+                    <= L[i - 2] + AVG_FACTOR[CandleSetting.Near] * near_total
+                )
+                or (
+                    # (bear) 4th: higher high and higher low
+                    H[i] > H[i - 1]
+                    and L[i] > L[i - 1]
+                    # (bear) 2nd: close near the top
+                    and C[i - 2]
+                    >= H[i - 2] - AVG_FACTOR[CandleSetting.Near] * near_total
+                )
+            )
+        ):
+            pattern_result = 100 * (1 if H[i] < H[i - 1] else -1)
+            pattern_idx = i
+        else:
+            # Search for confirmation
+            if i <= pattern_idx + 3 and (
+                (pattern_result > 0 and C[i] > H[pattern_idx - 1])
+                or (pattern_result < 0 and C[i] < L[pattern_idx - 1])
+            ):
+                pattern_idx = 0
+
+        near_total += arr_nr[i - 2] - arr_nr[near_trail - 2]
+        near_trail += 1
+
+    # Main loop
+    for i in range(start_idx, len(out)):
+        if (
+            # 2nd: lower high and higher low than 1st
+            H[i - 2] < H[i - 3]
+            and L[i - 2] > L[i - 3]
+            # 3rd: lower high and higher low than 2nd
+            and H[i - 1] < H[i - 2]
+            and L[i - 1] > L[i - 2]
+            and (
+                (
+                    # (bull) 4th: lower high and lower low
+                    H[i] < H[i - 1]
+                    and L[i] < L[i - 1]
+                    # (bull) 2nd: close near the low
+                    and C[i - 2]
+                    <= L[i - 2] + AVG_FACTOR[CandleSetting.Near] * near_total
+                )
+                or (
+                    # (bear) 4th: higher high and higher low
+                    H[i] > H[i - 1]
+                    and L[i] > L[i - 1]
+                    # (bear) 2nd: close near the top
+                    and C[i - 2]
+                    >= H[i - 2] - AVG_FACTOR[CandleSetting.Near] * near_total
+                )
+            )
+        ):
+            pattern_result = 100 * (1 if H[i] < H[i - 1] else -1)
+            pattern_idx = i
+            out[i] = pattern_result
+        elif i <= pattern_idx + 3 and (
+            (pattern_result > 0 and C[i] > H[pattern_idx - 1])
+            or (pattern_result < 0 and C[i] < L[pattern_idx - 1])
+        ):
+            out[i] = pattern_result + 100 * (1 if pattern_result > 0 else -1)
+            pattern_idx = 0
+
+        near_total += arr_nr[i - 2] - arr_nr[near_trail - 2]
+        near_trail += 1
+
+
+def cdl_hikkakemod(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Modified Hikkake
+
+    Like the standard Hikkake but adds a requirement that the second
+    candle has a close near its low (bullish) or near its high (bearish),
+    and requires two nested inside bars (bar 2 inside bar 1, bar 3
+    inside bar 2) before the breakout bar.
+
+    The pattern bar outputs +/-100 and the confirmation bar outputs
+    +/-200.
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        scalar: Multiplier for output values. Default: 100.
+        offset: Number of periods to shift the result.
+
+    Returns:
+        A Series with pattern signals, or None.
+
+    Example:
+        >>> result = cdl_hikkakemod(df.open, df.high, df.low, df.close)
+    """
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_HIKKAKEMOD",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_homingpigeon.py
+++ b/pandas_ta_classic/candles/cdl_homingpigeon.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    lookback = max(body_short_period, body_long_period) + 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+
+    body_long_trail = start_idx - 1 - body_long_period
+    body_short_trail = start_idx - body_short_period
+    body_long_total = float(arr_bl[body_long_trail : start_idx - 1].sum())
+    body_short_total = float(arr_bs[body_short_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 1] == -1
+            and ca.color[i] == -1
+            and ca.real_body[i - 1]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.real_body[i]
+            <= AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            and ca.open[i] < ca.open[i - 1]
+            and ca.close[i] > ca.close[i - 1]
+        ):
+            out[i] = 100
+
+        body_long_total += arr_bl[i - 1] - arr_bl[body_long_trail]
+        body_short_total += arr_bs[i] - arr_bs[body_short_trail]
+        body_long_trail += 1
+        body_short_trail += 1
+
+
+def cdl_homingpigeon(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Homingpigeon"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_HOMINGPIGEON",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_identical3crows.py
+++ b/pandas_ta_classic/candles/cdl_identical3crows.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Lookback: max(TA_CANDLEAVGPERIOD(ShadowVeryShort),
+    #               TA_CANDLEAVGPERIOD(Equal)) + 2
+    svs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    equal_period = candle_avg_period(CandleSetting.Equal)
+    lookback = max(svs_period, equal_period) + 2
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_eq = ca._ranges[CandleSetting.Equal]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+
+    svs_trail = start_idx - svs_period
+    equal_trail = start_idx - equal_period
+
+    # Seed ShadowVeryShort totals for i-2, i-1, i (indices 2, 1, 0)
+    svs_total_2 = float(arr_svs[svs_trail - 2 : start_idx - 2].sum())
+    svs_total_1 = float(arr_svs[svs_trail - 1 : start_idx - 1].sum())
+    svs_total_0 = float(arr_svs[svs_trail:start_idx].sum())
+    # Seed Equal totals for i-2, i-1 (indices 2, 1)
+    equal_total_2 = float(arr_eq[equal_trail - 2 : start_idx - 2].sum())
+    equal_total_1 = float(arr_eq[equal_trail - 1 : start_idx - 1].sum())
+    O = ca.open
+    C = ca.close
+
+    for i in range(start_idx, len(out)):
+        if (
+            # 1st black
+            ca.color[i - 2] == -1
+            # very short lower shadow
+            and ca.lower_shadow[i - 2]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total_2
+            # 2nd black
+            and ca.color[i - 1] == -1
+            # very short lower shadow
+            and ca.lower_shadow[i - 1]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total_1
+            # 3rd black
+            and ca.color[i] == -1
+            # very short lower shadow
+            and ca.lower_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total_0
+            # Three declining closes
+            and C[i - 2] > C[i - 1]
+            and C[i - 1] > C[i]
+            # 2nd opens very close to 1st close
+            and O[i - 1] <= C[i - 2] + AVG_FACTOR[CandleSetting.Equal] * equal_total_2
+            and O[i - 1] >= C[i - 2] - AVG_FACTOR[CandleSetting.Equal] * equal_total_2
+            # 3rd opens very close to 2nd close
+            and O[i] <= C[i - 1] + AVG_FACTOR[CandleSetting.Equal] * equal_total_1
+            and O[i] >= C[i - 1] - AVG_FACTOR[CandleSetting.Equal] * equal_total_1
+        ):
+            out[i] = -100
+
+        # Update ShadowVeryShort totals
+        svs_total_2 += arr_svs[i - 2] - arr_svs[svs_trail - 2]
+        svs_total_1 += arr_svs[i - 1] - arr_svs[svs_trail - 1]
+        svs_total_0 += arr_svs[i] - arr_svs[svs_trail]
+        # Update Equal totals
+        equal_total_2 += arr_eq[i - 2] - arr_eq[equal_trail - 2]
+        equal_total_1 += arr_eq[i - 1] - arr_eq[equal_trail - 1]
+
+        svs_trail += 1
+        equal_trail += 1
+
+
+def cdl_identical3crows(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Identical Three Crows
+
+    Three consecutive declining black (bearish) candlesticks, each with
+    very short lower shadows. Each candle after the first opens at or
+    very close to the prior candle's close (the "identical" open
+    distinguishes this from regular Three Black Crows).
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        scalar: Multiplier for output values. Default: 100.
+        offset: Number of periods to shift the result.
+
+    Returns:
+        A Series with -100 (bearish) / 0, or None.
+
+    Example:
+        >>> result = cdl_identical3crows(df.open, df.high, df.low, df.close)
+    """
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_IDENTICAL3CROWS",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_inneck.py
+++ b/pandas_ta_classic/candles/cdl_inneck.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    equal_period = candle_avg_period(CandleSetting.Equal)
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    lookback = max(equal_period, body_long_period) + 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_eq = ca._ranges[CandleSetting.Equal]
+
+    equal_trail = start_idx - 1 - equal_period
+    body_long_trail = start_idx - 1 - body_long_period
+    equal_total = float(arr_eq[equal_trail : start_idx - 1].sum())
+    body_long_total = float(arr_bl[body_long_trail : start_idx - 1].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 1] == -1
+            and ca.real_body[i - 1]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.color[i] == 1
+            and ca.open[i] < ca.low[i - 1]
+            and ca.close[i]
+            <= ca.close[i - 1] + AVG_FACTOR[CandleSetting.Equal] * equal_total
+            and ca.close[i] >= ca.close[i - 1]
+        ):
+            out[i] = -100
+
+        equal_total += arr_eq[i - 1] - arr_eq[equal_trail]
+        body_long_total += arr_bl[i - 1] - arr_bl[body_long_trail]
+        equal_trail += 1
+        body_long_trail += 1
+
+
+def cdl_inneck(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Inneck"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_INNECK",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_invertedhammer.py
+++ b/pandas_ta_classic/candles/cdl_invertedhammer.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    shadow_long_period = candle_avg_period(CandleSetting.ShadowLong)
+    shadow_vs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    lookback = max(body_short_period, shadow_long_period, shadow_vs_period)
+    lookback += 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    arr_sl = ca._ranges[CandleSetting.ShadowLong]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    body_short_trail = start_idx - body_short_period
+    shadow_long_trail = start_idx - shadow_long_period
+    shadow_vs_trail = start_idx - shadow_vs_period
+    body_short_total = float(arr_bs[body_short_trail:start_idx].sum())
+    shadow_long_total = float(arr_sl[shadow_long_trail:start_idx].sum())
+    shadow_vs_total = float(arr_svs[shadow_vs_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i] < AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            and ca.upper_shadow[i] > AVG_FACTOR[CandleSetting.ShadowLong] * arr_sl[i]
+            and ca.lower_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+            and body_hi[i] < body_lo[i - 1]
+        ):
+            out[i] = 100
+
+        # Update trailing windows
+        body_short_total += arr_bs[i] - arr_bs[body_short_trail]
+        shadow_long_total += arr_sl[i] - arr_sl[shadow_long_trail]
+        shadow_vs_total += arr_svs[i] - arr_svs[shadow_vs_trail]
+        body_short_trail += 1
+        shadow_long_trail += 1
+        shadow_vs_trail += 1
+
+
+def cdl_invertedhammer(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Invertedhammer"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_INVERTEDHAMMER",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_kicking.py
+++ b/pandas_ta_classic/candles/cdl_kicking.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    shadow_vs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    lookback = max(shadow_vs_period, body_long_period) + 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+    hi = ca.high
+    lo = ca.low
+
+    shadow_vs_trail = start_idx - shadow_vs_period
+    body_long_trail = start_idx - body_long_period
+
+    # Arrays for [0]=current bar, [1]=prior bar
+    shadow_vs_total = [0.0, 0.0]
+    body_long_total = [0.0, 0.0]
+
+    for j in range(shadow_vs_trail, start_idx):
+        shadow_vs_total[1] += arr_svs[j - 1]
+        shadow_vs_total[0] += arr_svs[j]
+
+    for j in range(body_long_trail, start_idx):
+        body_long_total[1] += arr_bl[j - 1]
+        body_long_total[0] += arr_bl[j]
+
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 1] == -ca.color[i]
+            and ca.real_body[i - 1]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total[1]
+            and ca.upper_shadow[i - 1]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total[1]
+            and ca.lower_shadow[i - 1]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total[1]
+            and ca.real_body[i]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total[0]
+            and ca.upper_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total[0]
+            and ca.lower_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total[0]
+            and (
+                (ca.color[i - 1] == -1 and lo[i] > hi[i - 1])
+                or (ca.color[i - 1] == 1 and hi[i] < lo[i - 1])
+            )
+        ):
+            out[i] = ca.color[i] * 100
+
+        for tot_idx in range(2):
+            body_long_total[tot_idx] += (
+                arr_bl[i - tot_idx] - arr_bl[body_long_trail - tot_idx]
+            )
+            shadow_vs_total[tot_idx] += (
+                arr_svs[i - tot_idx] - arr_svs[shadow_vs_trail - tot_idx]
+            )
+        body_long_trail += 1
+        shadow_vs_trail += 1
+
+
+def cdl_kicking(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Kicking"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_KICKING",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_kickingbylength.py
+++ b/pandas_ta_classic/candles/cdl_kickingbylength.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    shadow_vs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    lookback = max(shadow_vs_period, body_long_period) + 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+    hi = ca.high
+    lo = ca.low
+
+    shadow_vs_trail = start_idx - shadow_vs_period
+    body_long_trail = start_idx - body_long_period
+
+    shadow_vs_total = [0.0, 0.0]
+    body_long_total = [0.0, 0.0]
+
+    for j in range(shadow_vs_trail, start_idx):
+        shadow_vs_total[1] += arr_svs[j - 1]
+        shadow_vs_total[0] += arr_svs[j]
+
+    for j in range(body_long_trail, start_idx):
+        body_long_total[1] += arr_bl[j - 1]
+        body_long_total[0] += arr_bl[j]
+
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 1] == -ca.color[i]
+            and ca.real_body[i - 1]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total[1]
+            and ca.upper_shadow[i - 1]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total[1]
+            and ca.lower_shadow[i - 1]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total[1]
+            and ca.real_body[i]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total[0]
+            and ca.upper_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total[0]
+            and ca.lower_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total[0]
+            and (
+                (ca.color[i - 1] == -1 and lo[i] > hi[i - 1])
+                or (ca.color[i - 1] == 1 and hi[i] < lo[i - 1])
+            )
+        ):
+            out[i] = (
+                ca.color[i if ca.real_body[i] > ca.real_body[i - 1] else i - 1] * 100
+            )
+
+        for tot_idx in range(2):
+            body_long_total[tot_idx] += (
+                arr_bl[i - tot_idx] - arr_bl[body_long_trail - tot_idx]
+            )
+            shadow_vs_total[tot_idx] += (
+                arr_svs[i - tot_idx] - arr_svs[shadow_vs_trail - tot_idx]
+            )
+        body_long_trail += 1
+        shadow_vs_trail += 1
+
+
+def cdl_kickingbylength(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Kickingbylength"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_KICKINGBYLENGTH",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_ladderbottom.py
+++ b/pandas_ta_classic/candles/cdl_ladderbottom.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Lookback: TA_CANDLEAVGPERIOD(ShadowVeryShort) + 4
+    svs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    lookback = svs_period + 4
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+
+    svs_trail = start_idx - svs_period
+
+    # Seed ShadowVeryShort total: applied to bar i-1
+    svs_total = float(arr_svs[svs_trail - 1 : start_idx - 1].sum())
+    O = ca.open
+    H = ca.high
+    C = ca.close
+
+    for i in range(start_idx, len(out)):
+        if (
+            # First three are black candlesticks
+            ca.color[i - 4] == -1
+            and ca.color[i - 3] == -1
+            and ca.color[i - 2] == -1
+            # With consecutively lower opens
+            and O[i - 4] > O[i - 3]
+            and O[i - 3] > O[i - 2]
+            # And consecutively lower closes
+            and C[i - 4] > C[i - 3]
+            and C[i - 3] > C[i - 2]
+            # 4th: black with an upper shadow
+            and ca.color[i - 1] == -1
+            and ca.upper_shadow[i - 1]
+            > AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total
+            # 5th: white
+            and ca.color[i] == 1
+            # That opens above prior candle's body (open, since bearish)
+            and O[i] > O[i - 1]
+            # And closes above prior candle's high
+            and C[i] > H[i - 1]
+        ):
+            out[i] = 100
+
+        # Update total: add current range, subtract trailing range
+        svs_total += arr_svs[i - 1] - arr_svs[svs_trail - 1]
+        svs_trail += 1
+
+
+def cdl_ladderbottom(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Ladder Bottom
+
+    A 5-candle bullish reversal pattern. Three consecutive black candles
+    with lower opens and closes, followed by a black candle with a
+    notable upper shadow, then a white candle that opens above the
+    fourth candle's body and closes above its high.
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        scalar: Multiplier for output values. Default: 100.
+        offset: Number of periods to shift the result.
+
+    Returns:
+        A Series with +100 (bullish) / 0, or None.
+
+    Example:
+        >>> result = cdl_ladderbottom(df.open, df.high, df.low, df.close)
+    """
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_LADDERBOTTOM",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_longleggeddoji.py
+++ b/pandas_ta_classic/candles/cdl_longleggeddoji.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_doji_period = candle_avg_period(CandleSetting.BodyDoji)
+    shadow_long_period = candle_avg_period(CandleSetting.ShadowLong)
+    lookback = max(body_doji_period, shadow_long_period)
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bd = ca._ranges[CandleSetting.BodyDoji]
+    arr_sl = ca._ranges[CandleSetting.ShadowLong]
+
+    body_doji_trail = start_idx - body_doji_period
+    shadow_long_trail = start_idx - shadow_long_period
+    body_doji_total = float(arr_bd[body_doji_trail:start_idx].sum())
+    shadow_long_total = float(arr_sl[shadow_long_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if ca.real_body[i] <= AVG_FACTOR[CandleSetting.BodyDoji] * body_doji_total and (
+            ca.lower_shadow[i] > AVG_FACTOR[CandleSetting.ShadowLong] * arr_sl[i]
+            or ca.upper_shadow[i] > AVG_FACTOR[CandleSetting.ShadowLong] * arr_sl[i]
+        ):
+            out[i] = 100
+
+        # Update trailing windows
+        body_doji_total += arr_bd[i] - arr_bd[body_doji_trail]
+        shadow_long_total += arr_sl[i] - arr_sl[shadow_long_trail]
+        body_doji_trail += 1
+        shadow_long_trail += 1
+
+
+def cdl_longleggeddoji(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Longleggeddoji"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_LONGLEGGEDDOJI",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_longline.py
+++ b/pandas_ta_classic/candles/cdl_longline.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    shadow_short_period = candle_avg_period(CandleSetting.ShadowShort)
+    lookback = max(body_long_period, shadow_short_period)
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_ss = ca._ranges[CandleSetting.ShadowShort]
+
+    body_long_trail = start_idx - body_long_period
+    shadow_short_trail = start_idx - shadow_short_period
+    body_long_total = float(arr_bl[body_long_trail:start_idx].sum())
+    shadow_short_total = float(arr_ss[shadow_short_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.upper_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowShort] * shadow_short_total
+            and ca.lower_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowShort] * shadow_short_total
+        ):
+            out[i] = ca.color[i] * 100
+
+        # Update trailing windows
+        body_long_total += arr_bl[i] - arr_bl[body_long_trail]
+        shadow_short_total += arr_ss[i] - arr_ss[shadow_short_trail]
+        body_long_trail += 1
+        shadow_short_trail += 1
+
+
+def cdl_longline(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Longline"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_LONGLINE",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_marubozu.py
+++ b/pandas_ta_classic/candles/cdl_marubozu.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    shadow_vs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    lookback = max(body_long_period, shadow_vs_period)
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+
+    body_long_trail = start_idx - body_long_period
+    shadow_vs_trail = start_idx - shadow_vs_period
+    body_long_total = float(arr_bl[body_long_trail:start_idx].sum())
+    shadow_vs_total = float(arr_svs[shadow_vs_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.upper_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+            and ca.lower_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+        ):
+            out[i] = ca.color[i] * 100
+
+        # Update trailing windows
+        body_long_total += arr_bl[i] - arr_bl[body_long_trail]
+        shadow_vs_total += arr_svs[i] - arr_svs[shadow_vs_trail]
+        body_long_trail += 1
+        shadow_vs_trail += 1
+
+
+def cdl_marubozu(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Marubozu"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_MARUBOZU",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_matchinglow.py
+++ b/pandas_ta_classic/candles/cdl_matchinglow.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    equal_period = candle_avg_period(CandleSetting.Equal)
+    lookback = equal_period + 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_eq = ca._ranges[CandleSetting.Equal]
+
+    equal_trail = start_idx - 1 - equal_period
+    equal_total = float(arr_eq[equal_trail : start_idx - 1].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 1] == -1
+            and ca.color[i] == -1
+            and ca.close[i]
+            <= ca.close[i - 1] + AVG_FACTOR[CandleSetting.Equal] * equal_total
+            and ca.close[i]
+            >= ca.close[i - 1] - AVG_FACTOR[CandleSetting.Equal] * equal_total
+        ):
+            out[i] = 100
+
+        equal_total += arr_eq[i - 1] - arr_eq[equal_trail]
+        equal_trail += 1
+
+
+def cdl_matchinglow(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Matchinglow"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_MATCHINGLOW",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_mathold.py
+++ b/pandas_ta_classic/candles/cdl_mathold.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    penetration = kwargs.get("penetration", 0.5)
+
+    # Lookback: max(TA_CANDLEAVGPERIOD(BodyShort), TA_CANDLEAVGPERIOD(BodyLong)) + 4
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    lookback = max(body_short_period, body_long_period) + 4
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    body_short_trail = start_idx - body_short_period
+    body_long_trail = start_idx - body_long_period
+
+    # Seed body totals: [0]=unused, [1..3]=BodyShort at i-1..i-3, [4]=BodyLong at i-4
+    body_total = [0.0, 0.0, 0.0, 0.0, 0.0]
+
+    # Seed BodyShort totals for i-3, i-2, i-1
+    j = body_short_trail
+    while j < start_idx:
+        body_total[3] += arr_bs[j - 3]
+        body_total[2] += arr_bs[j - 2]
+        body_total[1] += arr_bs[j - 1]
+        j += 1
+
+    # Seed BodyLong total for i-4
+    j = body_long_trail
+    while j < start_idx:
+        body_total[4] += arr_bl[j - 4]
+        j += 1
+
+    O = ca.open
+    H = ca.high
+    C = ca.close
+
+    for i in range(start_idx, len(out)):
+        if (
+            # 1st long, then 3 small
+            ca.real_body[i - 4] > AVG_FACTOR[CandleSetting.BodyLong] * body_total[4]
+            and ca.real_body[i - 3]
+            < AVG_FACTOR[CandleSetting.BodyShort] * body_total[3]
+            and ca.real_body[i - 2]
+            < AVG_FACTOR[CandleSetting.BodyShort] * body_total[2]
+            and ca.real_body[i - 1]
+            < AVG_FACTOR[CandleSetting.BodyShort] * body_total[1]
+            # white, black, ?, ?, white
+            and ca.color[i - 4] == 1
+            and ca.color[i - 3] == -1
+            and ca.color[i] == 1
+            # upside gap 1st to 2nd
+            and body_lo[i - 3] > body_hi[i - 4]
+            # 3rd to 4th hold within 1st: part of real body within 1st body
+            and min(O[i - 2], C[i - 2]) < C[i - 4]
+            and min(O[i - 1], C[i - 1]) < C[i - 4]
+            # reaction days penetrate first body less than penetration %
+            and min(O[i - 2], C[i - 2]) > C[i - 4] - ca.real_body[i - 4] * penetration
+            and min(O[i - 1], C[i - 1]) > C[i - 4] - ca.real_body[i - 4] * penetration
+            # 2nd to 4th are falling
+            and max(C[i - 2], O[i - 2]) < O[i - 3]
+            and max(C[i - 1], O[i - 1]) < max(C[i - 2], O[i - 2])
+            # 5th opens above the prior close
+            and O[i] > C[i - 1]
+            # 5th closes above the highest high of the reaction days
+            and C[i] > max(max(H[i - 3], H[i - 2]), H[i - 1])
+        ):
+            out[i] = 100  # Always bullish
+
+        # Update totals
+        body_total[4] += arr_bl[i - 4] - arr_bl[body_long_trail - 4]
+        for k in range(3, 0, -1):
+            body_total[k] += arr_bs[i - k] - arr_bs[body_short_trail - k]
+        body_short_trail += 1
+        body_long_trail += 1
+
+
+def cdl_mathold(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    penetration: Optional[float] = None,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Mat Hold
+
+    A 5-candle bullish continuation pattern. Begins with a long white
+    candle, followed by a gap-up and three small declining candles that
+    stay within the first candle's body (penetrating no more than
+    ``penetration`` percent), then a white candle that closes above the
+    highest high of the reaction days.
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        penetration: Maximum penetration of the first body by reaction
+            days. Default: 0.5.
+        scalar: Multiplier for output values. Default: 100.
+        offset: Number of periods to shift the result.
+
+    Returns:
+        A Series with +100 (bullish) / 0, or None.
+
+    Example:
+        >>> result = cdl_mathold(df.open, df.high, df.low, df.close, penetration=0.5)
+    """
+    if penetration is None:
+        penetration = 0.5
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_MATHOLD",
+        scalar=scalar,
+        offset=offset,
+        penetration=penetration,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_morningdojistar.py
+++ b/pandas_ta_classic/candles/cdl_morningdojistar.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    penetration = kwargs.get("penetration", 0.3)
+
+    # Lookback: max(BodyDoji, BodyLong, BodyShort) + 2
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    body_doji_period = candle_avg_period(CandleSetting.BodyDoji)
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    lookback = max(body_doji_period, body_long_period, body_short_period) + 2
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bd = ca._ranges[CandleSetting.BodyDoji]
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    # Trailing indices
+    # BodyLong at offset i-2: trail = startIdx - 2 - period
+    body_long_trail = start_idx - 2 - body_long_period
+    # BodyDoji at offset i-1: trail = startIdx - 1 - period
+    body_doji_trail = start_idx - 1 - body_doji_period
+    # BodyShort at offset i: trail = startIdx - period
+    body_short_trail = start_idx - body_short_period
+
+    # Seed totals
+    body_long_total = float(arr_bl[body_long_trail : start_idx - 2].sum())
+    body_doji_total = float(arr_bd[body_doji_trail : start_idx - 1].sum())
+    body_short_total = float(arr_bs[body_short_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            # 1st: long black
+            ca.real_body[i - 2] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.color[i - 2] == -1
+            # 2nd: doji gapping down
+            and ca.real_body[i - 1]
+            <= AVG_FACTOR[CandleSetting.BodyDoji] * body_doji_total
+            and body_hi[i - 1] < body_lo[i - 2]
+            # 3rd: longer than short, white, closing well within 1st rb
+            and ca.real_body[i] > AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            and ca.color[i] == 1
+            and ca.close[i] > ca.close[i - 2] + ca.real_body[i - 2] * penetration
+        ):
+            out[i] = 100
+
+        # Update trailing windows
+        body_long_total += arr_bl[i - 2] - arr_bl[body_long_trail]
+        body_doji_total += arr_bd[i - 1] - arr_bd[body_doji_trail]
+        body_short_total += arr_bs[i] - arr_bs[body_short_trail]
+        body_long_trail += 1
+        body_doji_trail += 1
+        body_short_trail += 1
+
+
+def cdl_morningdojistar(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    penetration: Optional[float] = None,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Morning Doji Star
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        penetration: Percentage of penetration within the first candle's
+            real body. Default: 0.3
+        scalar: Multiplier for output values. Default: 100.
+        offset: How many periods to shift the result.
+
+    Returns:
+        A pandas Series with +100 (bullish) or 0.
+    """
+    if penetration is None:
+        penetration = 0.3
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_MORNINGDOJISTAR",
+        scalar=scalar,
+        offset=offset,
+        penetration=penetration,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_morningstar.py
+++ b/pandas_ta_classic/candles/cdl_morningstar.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    penetration = kwargs.get("penetration", 0.3)
+
+    # Lookback: max(BodyShort, BodyLong) + 2
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    lookback = max(body_short_period, body_long_period) + 2
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    # Trailing indices
+    # BodyLong at offset i-2: trail = startIdx - 2 - period
+    body_long_trail = start_idx - 2 - body_long_period
+    # BodyShort at offset i-1: trail = startIdx - 1 - period
+    # Both BodyShort totals share the same trailing index
+    body_short_trail = start_idx - 1 - body_short_period
+
+    # Seed totals
+    body_long_total = float(arr_bl[body_long_trail : start_idx - 2].sum())
+    # BodyShortPeriodTotal tracks BodyShort at i-1
+    # BodyShortPeriodTotal2 tracks BodyShort at i
+    body_short_total = float(arr_bs[body_short_trail : start_idx - 1].sum())
+    body_short_total2 = float(arr_bs[body_short_trail + 1 : start_idx - 1 + 1].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            # 1st: long black
+            ca.real_body[i - 2] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.color[i - 2] == -1
+            # 2nd: short, gapping down
+            and ca.real_body[i - 1]
+            <= AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            and body_hi[i - 1] < body_lo[i - 2]
+            # 3rd: longer than short, white, closing well within 1st rb
+            and ca.real_body[i]
+            > AVG_FACTOR[CandleSetting.BodyShort] * body_short_total2
+            and ca.color[i] == 1
+            and ca.close[i] > ca.close[i - 2] + ca.real_body[i - 2] * penetration
+        ):
+            out[i] = 100
+
+        # Update trailing windows
+        body_long_total += arr_bl[i - 2] - arr_bl[body_long_trail]
+        body_short_total += arr_bs[i - 1] - arr_bs[body_short_trail]
+        body_short_total2 += arr_bs[i] - arr_bs[body_short_trail + 1]
+        body_long_trail += 1
+        body_short_trail += 1
+
+
+def cdl_morningstar(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    penetration: Optional[float] = None,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Morning Star
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        penetration: Percentage of penetration within the first candle's
+            real body. Default: 0.3
+        scalar: Multiplier for output values. Default: 100.
+        offset: How many periods to shift the result.
+
+    Returns:
+        A pandas Series with +100 (bullish) or 0.
+    """
+    if penetration is None:
+        penetration = 0.3
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_MORNINGSTAR",
+        scalar=scalar,
+        offset=offset,
+        penetration=penetration,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_onneck.py
+++ b/pandas_ta_classic/candles/cdl_onneck.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    equal_period = candle_avg_period(CandleSetting.Equal)
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    lookback = max(equal_period, body_long_period) + 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_eq = ca._ranges[CandleSetting.Equal]
+
+    equal_trail = start_idx - 1 - equal_period
+    body_long_trail = start_idx - 1 - body_long_period
+    equal_total = float(arr_eq[equal_trail : start_idx - 1].sum())
+    body_long_total = float(arr_bl[body_long_trail : start_idx - 1].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 1] == -1
+            and ca.real_body[i - 1]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.color[i] == 1
+            and ca.open[i] < ca.low[i - 1]
+            and ca.close[i]
+            <= ca.low[i - 1] + AVG_FACTOR[CandleSetting.Equal] * equal_total
+            and ca.close[i]
+            >= ca.low[i - 1] - AVG_FACTOR[CandleSetting.Equal] * equal_total
+        ):
+            out[i] = -100
+
+        equal_total += arr_eq[i - 1] - arr_eq[equal_trail]
+        body_long_total += arr_bl[i - 1] - arr_bl[body_long_trail]
+        equal_trail += 1
+        body_long_trail += 1
+
+
+def cdl_onneck(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Onneck"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_ONNECK",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_pattern.py
+++ b/pandas_ta_classic/candles/cdl_pattern.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 # Candle Pattern (CDL_PATTERN)
+import importlib
 import logging
-from typing import Any, Optional, Sequence, Union
+import os
+from collections.abc import Sequence
+from typing import Any, Optional, Union
 from pandas import Series, DataFrame
 
 from . import cdl_doji, cdl_inside
@@ -76,6 +79,32 @@ ALL_PATTERNS = [
 ]
 
 
+def _discover_native_patterns() -> dict:
+    """Auto-discover native cdl_*.py pattern implementations."""
+    skip = {"cdl_pattern", "cdl_z", "cdl_inside", "cdl_doji"}
+    native = {}
+    pkg_dir = os.path.dirname(__file__)
+    for fname in os.listdir(pkg_dir):
+        if not fname.startswith("cdl_") or not fname.endswith(".py"):
+            continue
+        mod_name = fname[:-3]  # strip .py
+        if mod_name in skip:
+            continue
+        pattern_name = mod_name[4:]  # strip cdl_
+        try:
+            mod = importlib.import_module(f".{mod_name}", package=__package__)
+            func = getattr(mod, mod_name, None)
+            if callable(func):
+                native[pattern_name] = func
+        except Exception:
+            pass
+    return native
+
+
+# Pre-built dict of native pattern name -> callable
+_NATIVE_PATTERNS = _discover_native_patterns()
+
+
 def cdl_pattern(
     open_: Series,
     high: Series,
@@ -92,10 +121,14 @@ def cdl_pattern(
     high = verify_series(high)
     low = verify_series(low)
     close = verify_series(close)
+
+    if open_ is None or high is None or low is None or close is None:
+        return None
+
     offset = get_offset(offset)
     scalar = float(scalar) if scalar else 100
 
-    # Patterns that implemented in pandas-ta
+    # Patterns with custom implementations (non-standard signatures)
     pta_patterns = {
         "doji": cdl_doji,
         "inside": cdl_inside,
@@ -112,21 +145,25 @@ def cdl_pattern(
     result = {}
     for n in name:
         if n not in ALL_PATTERNS:
-            logger.warning(f"There is no candle pattern named {n} available!")
+            logger.warning("There is no candle pattern named %s available!", n)
             continue
+
+        col_name = f"CDL_{n.upper()}"
 
         if n in pta_patterns:
             pattern_result = pta_patterns[n](
                 open_, high, low, close, offset=offset, scalar=scalar, **kwargs
             )
             result[pattern_result.name] = pattern_result
-        else:
-            if not Imports["talib"]:
-                logger.warning(
-                    f"Please install TA-Lib to use {n}. (pip install TA-Lib)"
-                )
-                continue
-
+        elif n in _NATIVE_PATTERNS:
+            # Use native implementation (no TA-Lib required)
+            pattern_result = _NATIVE_PATTERNS[n](
+                open_, high, low, close, scalar=scalar, offset=offset, **kwargs
+            )
+            if pattern_result is not None:
+                result[col_name] = pattern_result
+        elif Imports["talib"]:
+            # Fall back to TA-Lib
             pattern_func = tala.Function(f"CDL{n.upper()}")
             pattern_result = Series(
                 pattern_func(open_, high, low, close, **kwargs) / 100 * scalar
@@ -141,19 +178,17 @@ def cdl_pattern(
             if "fillna" in kwargs:
                 pattern_result.fillna(kwargs["fillna"], inplace=True)
             if "fill_method" in kwargs:
-                if "fill_method" in kwargs:
+                if kwargs["fill_method"] == "ffill":
+                    pattern_result.ffill(inplace=True)
+                elif kwargs["fill_method"] == "bfill":
+                    pattern_result.bfill(inplace=True)
 
-                    if kwargs["fill_method"] == "ffill":
+            result[col_name] = pattern_result
+        else:
+            logger.warning("Please install TA-Lib to use %s. (pip install TA-Lib)", n)
+            continue
 
-                        pattern_result.ffill(inplace=True)
-
-                    elif kwargs["fill_method"] == "bfill":
-
-                        pattern_result.bfill(inplace=True)
-
-            result[f"CDL_{n.upper()}"] = pattern_result
-
-    if len(result) == 0:
+    if not result:
         return None
 
     # Prepare DataFrame to return

--- a/pandas_ta_classic/candles/cdl_piercing.py
+++ b/pandas_ta_classic/candles/cdl_piercing.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    lookback = body_long_period + 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+
+    body_long_trail = start_idx - body_long_period
+
+    body_long_total = [0.0, 0.0]
+    for j in range(body_long_trail, start_idx):
+        body_long_total[1] += arr_bl[j - 1]
+        body_long_total[0] += arr_bl[j]
+
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 1] == -1
+            and ca.real_body[i - 1]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total[1]
+            and ca.color[i] == 1
+            and ca.real_body[i]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total[0]
+            and ca.open[i] < ca.low[i - 1]
+            and ca.close[i] < ca.open[i - 1]
+            and ca.close[i] > ca.close[i - 1] + ca.real_body[i - 1] * 0.5
+        ):
+            out[i] = 100
+
+        for tot_idx in range(2):
+            body_long_total[tot_idx] += (
+                arr_bl[i - tot_idx] - arr_bl[body_long_trail - tot_idx]
+            )
+        body_long_trail += 1
+
+
+def cdl_piercing(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Piercing"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_PIERCING",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_rickshawman.py
+++ b/pandas_ta_classic/candles/cdl_rickshawman.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_doji_period = candle_avg_period(CandleSetting.BodyDoji)
+    shadow_long_period = candle_avg_period(CandleSetting.ShadowLong)
+    near_period = candle_avg_period(CandleSetting.Near)
+    lookback = max(body_doji_period, shadow_long_period, near_period)
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bd = ca._ranges[CandleSetting.BodyDoji]
+    arr_nr = ca._ranges[CandleSetting.Near]
+    arr_sl = ca._ranges[CandleSetting.ShadowLong]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    body_doji_trail = start_idx - body_doji_period
+    shadow_long_trail = start_idx - shadow_long_period
+    near_trail = start_idx - near_period
+    body_doji_total = float(arr_bd[body_doji_trail:start_idx].sum())
+    shadow_long_total = float(arr_sl[shadow_long_trail:start_idx].sum())
+    near_total = float(arr_nr[near_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i] <= AVG_FACTOR[CandleSetting.BodyDoji] * body_doji_total
+            and ca.lower_shadow[i] > AVG_FACTOR[CandleSetting.ShadowLong] * arr_sl[i]
+            and ca.upper_shadow[i] > AVG_FACTOR[CandleSetting.ShadowLong] * arr_sl[i]
+            and (
+                body_lo[i]
+                <= ca.low[i]
+                + ca.hl_range[i] / 2.0
+                + AVG_FACTOR[CandleSetting.Near] * near_total
+            )
+            and (
+                body_hi[i]
+                >= ca.low[i]
+                + ca.hl_range[i] / 2.0
+                - AVG_FACTOR[CandleSetting.Near] * near_total
+            )
+        ):
+            out[i] = 100
+
+        # Update trailing windows
+        body_doji_total += arr_bd[i] - arr_bd[body_doji_trail]
+        shadow_long_total += arr_sl[i] - arr_sl[shadow_long_trail]
+        near_total += arr_nr[i] - arr_nr[near_trail]
+        body_doji_trail += 1
+        shadow_long_trail += 1
+        near_trail += 1
+
+
+def cdl_rickshawman(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Rickshawman"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_RICKSHAWMAN",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_risefall3methods.py
+++ b/pandas_ta_classic/candles/cdl_risefall3methods.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Lookback: max(TA_CANDLEAVGPERIOD(BodyShort), TA_CANDLEAVGPERIOD(BodyLong)) + 4
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    lookback = max(body_short_period, body_long_period) + 4
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+
+    body_short_trail = start_idx - body_short_period
+    body_long_trail = start_idx - body_long_period
+
+    # [0]=BodyLong at i, [1..3]=BodyShort at i-1..i-3, [4]=BodyLong at i-4
+    body_total = [0.0, 0.0, 0.0, 0.0, 0.0]
+
+    # Seed BodyShort totals for i-3, i-2, i-1
+    j = body_short_trail
+    while j < start_idx:
+        body_total[3] += arr_bs[j - 3]
+        body_total[2] += arr_bs[j - 2]
+        body_total[1] += arr_bs[j - 1]
+        j += 1
+
+    # Seed BodyLong totals for i-4 and i (both use BodyLong period)
+    j = body_long_trail
+    while j < start_idx:
+        body_total[4] += arr_bl[j - 4]
+        body_total[0] += arr_bl[j]
+        j += 1
+
+    O = ca.open
+    H = ca.high
+    L = ca.low
+    C = ca.close
+
+    for i in range(start_idx, len(out)):
+        if (
+            # 1st long, then 3 small, 5th long
+            ca.real_body[i - 4] > AVG_FACTOR[CandleSetting.BodyLong] * body_total[4]
+            and ca.real_body[i - 3]
+            < AVG_FACTOR[CandleSetting.BodyShort] * body_total[3]
+            and ca.real_body[i - 2]
+            < AVG_FACTOR[CandleSetting.BodyShort] * body_total[2]
+            and ca.real_body[i - 1]
+            < AVG_FACTOR[CandleSetting.BodyShort] * body_total[1]
+            and ca.real_body[i] > AVG_FACTOR[CandleSetting.BodyLong] * body_total[0]
+            # white, 3 black, white  ||  black, 3 white, black
+            and ca.color[i - 4] == -ca.color[i - 3]
+            and ca.color[i - 3] == ca.color[i - 2]
+            and ca.color[i - 2] == ca.color[i - 1]
+            and ca.color[i - 1] == -ca.color[i]
+            # 2nd to 4th hold within 1st: part of real body within 1st range
+            and min(O[i - 3], C[i - 3]) < H[i - 4]
+            and max(O[i - 3], C[i - 3]) > L[i - 4]
+            and min(O[i - 2], C[i - 2]) < H[i - 4]
+            and max(O[i - 2], C[i - 2]) > L[i - 4]
+            and min(O[i - 1], C[i - 1]) < H[i - 4]
+            and max(O[i - 1], C[i - 1]) > L[i - 4]
+            # 2nd to 4th are falling (rising)
+            and C[i - 2] * ca.color[i - 4] < C[i - 3] * ca.color[i - 4]
+            and C[i - 1] * ca.color[i - 4] < C[i - 2] * ca.color[i - 4]
+            # 5th opens above (below) the prior close
+            and O[i] * ca.color[i - 4] > C[i - 1] * ca.color[i - 4]
+            # 5th closes above (below) the 1st close
+            and C[i] * ca.color[i - 4] > C[i - 4] * ca.color[i - 4]
+        ):
+            out[i] = 100 * ca.color[i - 4]
+
+        # Update totals
+        body_total[4] += arr_bl[i - 4] - arr_bl[body_long_trail - 4]
+        for k in range(3, 0, -1):
+            body_total[k] += arr_bs[i - k] - arr_bs[body_short_trail - k]
+        body_total[0] += arr_bl[i] - arr_bl[body_long_trail]
+        body_short_trail += 1
+        body_long_trail += 1
+
+
+def cdl_risefall3methods(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Rising/Falling Three Methods
+
+    A 5-candle continuation pattern. Rising Three Methods: long white
+    candle, three small declining black candles held within the first's
+    range, then a long white candle closing above the first's close.
+    Falling Three Methods is the bearish mirror.
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        scalar: Multiplier for output values. Default: 100.
+        offset: Number of periods to shift the result.
+
+    Returns:
+        A Series with +100 (rising) / -100 (falling) / 0, or None.
+
+    Example:
+        >>> result = cdl_risefall3methods(df.open, df.high, df.low, df.close)
+    """
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_RISEFALL3METHODS",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_separatinglines.py
+++ b/pandas_ta_classic/candles/cdl_separatinglines.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    shadow_vs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    equal_period = candle_avg_period(CandleSetting.Equal)
+    lookback = max(shadow_vs_period, body_long_period, equal_period) + 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_eq = ca._ranges[CandleSetting.Equal]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+
+    shadow_vs_trail = start_idx - shadow_vs_period
+    body_long_trail = start_idx - body_long_period
+    equal_trail = start_idx - 1 - equal_period
+    shadow_vs_total = float(arr_svs[shadow_vs_trail:start_idx].sum())
+    body_long_total = float(arr_bl[body_long_trail:start_idx].sum())
+    equal_total = float(arr_eq[equal_trail : start_idx - 1].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 1] == -ca.color[i]
+            and ca.open[i]
+            <= ca.open[i - 1] + AVG_FACTOR[CandleSetting.Equal] * equal_total
+            and ca.open[i]
+            >= ca.open[i - 1] - AVG_FACTOR[CandleSetting.Equal] * equal_total
+            and ca.real_body[i] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and (
+                (
+                    ca.color[i] == 1
+                    and ca.lower_shadow[i]
+                    < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+                )
+                or (
+                    ca.color[i] == -1
+                    and ca.upper_shadow[i]
+                    < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+                )
+            )
+        ):
+            out[i] = ca.color[i] * 100
+
+        shadow_vs_total += arr_svs[i] - arr_svs[shadow_vs_trail]
+        body_long_total += arr_bl[i] - arr_bl[body_long_trail]
+        equal_total += arr_eq[i - 1] - arr_eq[equal_trail]
+        shadow_vs_trail += 1
+        body_long_trail += 1
+        equal_trail += 1
+
+
+def cdl_separatinglines(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Separatinglines"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_SEPARATINGLINES",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_shootingstar.py
+++ b/pandas_ta_classic/candles/cdl_shootingstar.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    shadow_long_period = candle_avg_period(CandleSetting.ShadowLong)
+    shadow_vs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    lookback = max(body_short_period, shadow_long_period, shadow_vs_period)
+    lookback += 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    arr_sl = ca._ranges[CandleSetting.ShadowLong]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    body_short_trail = start_idx - body_short_period
+    shadow_long_trail = start_idx - shadow_long_period
+    shadow_vs_trail = start_idx - shadow_vs_period
+    body_short_total = float(arr_bs[body_short_trail:start_idx].sum())
+    shadow_long_total = float(arr_sl[shadow_long_trail:start_idx].sum())
+    shadow_vs_total = float(arr_svs[shadow_vs_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i] < AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            and ca.upper_shadow[i] > AVG_FACTOR[CandleSetting.ShadowLong] * arr_sl[i]
+            and ca.lower_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+            and body_lo[i] > body_hi[i - 1]
+        ):
+            out[i] = -100
+
+        # Update trailing windows
+        body_short_total += arr_bs[i] - arr_bs[body_short_trail]
+        shadow_long_total += arr_sl[i] - arr_sl[shadow_long_trail]
+        shadow_vs_total += arr_svs[i] - arr_svs[shadow_vs_trail]
+        body_short_trail += 1
+        shadow_long_trail += 1
+        shadow_vs_trail += 1
+
+
+def cdl_shootingstar(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Shootingstar"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_SHOOTINGSTAR",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_shortline.py
+++ b/pandas_ta_classic/candles/cdl_shortline.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    shadow_short_period = candle_avg_period(CandleSetting.ShadowShort)
+    lookback = max(body_short_period, shadow_short_period)
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    arr_ss = ca._ranges[CandleSetting.ShadowShort]
+
+    body_short_trail = start_idx - body_short_period
+    shadow_short_trail = start_idx - shadow_short_period
+    body_short_total = float(arr_bs[body_short_trail:start_idx].sum())
+    shadow_short_total = float(arr_ss[shadow_short_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i] < AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            and ca.upper_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowShort] * shadow_short_total
+            and ca.lower_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowShort] * shadow_short_total
+        ):
+            out[i] = ca.color[i] * 100
+
+        # Update trailing windows
+        body_short_total += arr_bs[i] - arr_bs[body_short_trail]
+        shadow_short_total += arr_ss[i] - arr_ss[shadow_short_trail]
+        body_short_trail += 1
+        shadow_short_trail += 1
+
+
+def cdl_shortline(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Shortline"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_SHORTLINE",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_spinningtop.py
+++ b/pandas_ta_classic/candles/cdl_spinningtop.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    lookback = body_short_period
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+
+    body_short_trail = start_idx - body_short_period
+    body_short_total = float(arr_bs[body_short_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i] < AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            and ca.upper_shadow[i] > ca.real_body[i]
+            and ca.lower_shadow[i] > ca.real_body[i]
+        ):
+            out[i] = ca.color[i] * 100
+
+        # Update trailing windows
+        body_short_total += arr_bs[i] - arr_bs[body_short_trail]
+        body_short_trail += 1
+
+
+def cdl_spinningtop(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Spinningtop"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_SPINNINGTOP",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_stalledpattern.py
+++ b/pandas_ta_classic/candles/cdl_stalledpattern.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    # Lookback: max(max(BodyLong, BodyShort),
+    #               max(ShadowVeryShort, Near)) + 2
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    svs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    near_period = candle_avg_period(CandleSetting.Near)
+
+    lookback = (
+        max(
+            max(body_long_period, body_short_period),
+            max(svs_period, near_period),
+        )
+        + 2
+    )
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    arr_nr = ca._ranges[CandleSetting.Near]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+
+    body_long_trail = start_idx - body_long_period
+    body_short_trail = start_idx - body_short_period
+    svs_trail = start_idx - svs_period
+    near_trail = start_idx - near_period
+
+    # Seed BodyLong totals for i-2 and i-1 (indices 2, 1)
+    body_long_total_2 = float(arr_bl[body_long_trail - 2 : start_idx - 2].sum())
+    body_long_total_1 = float(arr_bl[body_long_trail - 1 : start_idx - 1].sum())
+    # Seed BodyShort total for i (index 0 / current bar)
+    body_short_total = float(arr_bs[body_short_trail:start_idx].sum())
+    # Seed ShadowVeryShort total for i-1
+    svs_total = float(arr_svs[svs_trail - 1 : start_idx - 1].sum())
+    # Seed Near totals for i-2 and i-1 (indices 2, 1)
+    near_total_2 = float(arr_nr[near_trail - 2 : start_idx - 2].sum())
+    near_total_1 = float(arr_nr[near_trail - 1 : start_idx - 1].sum())
+    O = ca.open
+    C = ca.close
+
+    for i in range(start_idx, len(out)):
+        if (
+            # 1st white
+            ca.color[i - 2] == 1
+            # 2nd white
+            and ca.color[i - 1] == 1
+            # 3rd white
+            and ca.color[i] == 1
+            # Consecutive higher closes
+            and C[i] > C[i - 1]
+            and C[i - 1] > C[i - 2]
+            # 1st: long real body
+            and ca.real_body[i - 2]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total_2
+            # 2nd: long real body
+            and ca.real_body[i - 1]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total_1
+            # 2nd: very short upper shadow
+            and ca.upper_shadow[i - 1]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * svs_total
+            # 2nd opens within/near 1st real body: opens above 1st open
+            and O[i - 1] > O[i - 2]
+            # 2nd opens at or below 1st close + Near average
+            and O[i - 1] <= C[i - 2] + AVG_FACTOR[CandleSetting.Near] * near_total_2
+            # 3rd: small real body
+            and ca.real_body[i] < AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            # 3rd rides on the shoulder of 2nd real body
+            and O[i]
+            >= C[i - 1]
+            - ca.real_body[i]
+            - AVG_FACTOR[CandleSetting.Near] * near_total_1
+        ):
+            out[i] = -100
+
+        # Update BodyLong and Near totals (indices 2 and 1)
+        body_long_total_2 += arr_bl[i - 2] - arr_bl[body_long_trail - 2]
+        body_long_total_1 += arr_bl[i - 1] - arr_bl[body_long_trail - 1]
+        near_total_2 += arr_nr[i - 2] - arr_nr[near_trail - 2]
+        near_total_1 += arr_nr[i - 1] - arr_nr[near_trail - 1]
+        # Update BodyShort total (index 0 / current bar)
+        body_short_total += arr_bs[i] - arr_bs[body_short_trail]
+        # Update ShadowVeryShort total (index 1 / bar i-1)
+        svs_total += arr_svs[i - 1] - arr_svs[svs_trail - 1]
+
+        body_long_trail += 1
+        body_short_trail += 1
+        svs_trail += 1
+        near_trail += 1
+
+
+def cdl_stalledpattern(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Stalled Pattern
+
+    Three white candlesticks with consecutively higher closes. The first
+    two have long real bodies; the second has a very short upper shadow
+    and opens within or near the first's real body. The third has a
+    small real body that gaps away or rides on the shoulder of the
+    second's body, signaling a potential reversal.
+
+    Args:
+        open_: Series of 'open' prices.
+        high: Series of 'high' prices.
+        low: Series of 'low' prices.
+        close: Series of 'close' prices.
+        scalar: Multiplier for output values. Default: 100.
+        offset: Number of periods to shift the result.
+
+    Returns:
+        A Series with -100 (bearish) / 0, or None.
+
+    Example:
+        >>> result = cdl_stalledpattern(df.open, df.high, df.low, df.close)
+    """
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_STALLEDPATTERN",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_sticksandwich.py
+++ b/pandas_ta_classic/candles/cdl_sticksandwich.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    equal_period = candle_avg_period(CandleSetting.Equal)
+    lookback = equal_period + 2
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_eq = ca._ranges[CandleSetting.Equal]
+
+    equal_trail = start_idx - 2 - equal_period
+    equal_total = float(arr_eq[equal_trail : start_idx - 2].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 2] == -1
+            and ca.color[i - 1] == 1
+            and ca.color[i] == -1
+            and ca.low[i - 1] > ca.close[i - 2]
+            and ca.close[i]
+            <= ca.close[i - 2] + AVG_FACTOR[CandleSetting.Equal] * equal_total
+            and ca.close[i]
+            >= ca.close[i - 2] - AVG_FACTOR[CandleSetting.Equal] * equal_total
+        ):
+            out[i] = 100
+
+        equal_total += arr_eq[i - 2] - arr_eq[equal_trail]
+        equal_trail += 1
+
+
+def cdl_sticksandwich(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Sticksandwich"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_STICKSANDWICH",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_takuri.py
+++ b/pandas_ta_classic/candles/cdl_takuri.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
+    body_doji_period = candle_avg_period(CandleSetting.BodyDoji)
+    shadow_vs_period = candle_avg_period(CandleSetting.ShadowVeryShort)
+    shadow_vl_period = candle_avg_period(CandleSetting.ShadowVeryLong)
+    lookback = max(body_doji_period, shadow_vs_period, shadow_vl_period)
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bd = ca._ranges[CandleSetting.BodyDoji]
+    arr_svl = ca._ranges[CandleSetting.ShadowVeryLong]
+    arr_svs = ca._ranges[CandleSetting.ShadowVeryShort]
+
+    body_doji_trail = start_idx - body_doji_period
+    shadow_vs_trail = start_idx - shadow_vs_period
+    shadow_vl_trail = start_idx - shadow_vl_period
+    body_doji_total = float(arr_bd[body_doji_trail:start_idx].sum())
+    shadow_vs_total = float(arr_svs[shadow_vs_trail:start_idx].sum())
+    shadow_vl_total = float(arr_svl[shadow_vl_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i] <= AVG_FACTOR[CandleSetting.BodyDoji] * body_doji_total
+            and ca.upper_shadow[i]
+            < AVG_FACTOR[CandleSetting.ShadowVeryShort] * shadow_vs_total
+            and ca.lower_shadow[i]
+            > AVG_FACTOR[CandleSetting.ShadowVeryLong] * arr_svl[i]
+        ):
+            out[i] = 100
+
+        # Update trailing windows
+        body_doji_total += arr_bd[i] - arr_bd[body_doji_trail]
+        shadow_vs_total += arr_svs[i] - arr_svs[shadow_vs_trail]
+        shadow_vl_total += arr_svl[i] - arr_svl[shadow_vl_trail]
+        body_doji_trail += 1
+        shadow_vs_trail += 1
+        shadow_vl_trail += 1
+
+
+def cdl_takuri(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Takuri"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_TAKURI",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_tasukigap.py
+++ b/pandas_ta_classic/candles/cdl_tasukigap.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    near_period = candle_avg_period(CandleSetting.Near)
+    lookback = near_period + 2
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_nr = ca._ranges[CandleSetting.Near]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    near_trail = start_idx - near_period
+    near_total = float(arr_nr[near_trail - 1 : start_idx - 1].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            body_lo[i - 1] > body_hi[i - 2]
+            and ca.color[i - 1] == 1
+            and ca.color[i] == -1
+            and ca.open[i] < ca.close[i - 1]
+            and ca.open[i] > ca.open[i - 1]
+            and ca.close[i] < ca.open[i - 1]
+            and ca.close[i] > body_hi[i - 2]
+            and abs(ca.real_body[i - 1] - ca.real_body[i])
+            < AVG_FACTOR[CandleSetting.Near] * near_total
+        ) or (
+            body_hi[i - 1] < body_lo[i - 2]
+            and ca.color[i - 1] == -1
+            and ca.color[i] == 1
+            and ca.open[i] < ca.open[i - 1]
+            and ca.open[i] > ca.close[i - 1]
+            and ca.close[i] > ca.open[i - 1]
+            and ca.close[i] < body_lo[i - 2]
+            and abs(ca.real_body[i - 1] - ca.real_body[i])
+            < AVG_FACTOR[CandleSetting.Near] * near_total
+        ):
+            out[i] = ca.color[i - 1] * 100
+
+        near_total += arr_nr[i - 1] - arr_nr[near_trail - 1]
+        near_trail += 1
+
+
+def cdl_tasukigap(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Tasuki Gap"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_TASUKIGAP",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_thrusting.py
+++ b/pandas_ta_classic/candles/cdl_thrusting.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    equal_period = candle_avg_period(CandleSetting.Equal)
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    lookback = max(equal_period, body_long_period) + 1
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_eq = ca._ranges[CandleSetting.Equal]
+
+    equal_trail = start_idx - 1 - equal_period
+    body_long_trail = start_idx - 1 - body_long_period
+    equal_total = float(arr_eq[equal_trail : start_idx - 1].sum())
+    body_long_total = float(arr_bl[body_long_trail : start_idx - 1].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 1] == -1
+            and ca.real_body[i - 1]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.color[i] == 1
+            and ca.open[i] < ca.low[i - 1]
+            and ca.close[i]
+            > ca.close[i - 1] + AVG_FACTOR[CandleSetting.Equal] * equal_total
+            and ca.close[i] <= ca.open[i - 1] - ca.real_body[i - 1] * 0.5
+        ):
+            out[i] = -100
+
+        equal_total += arr_eq[i - 1] - arr_eq[equal_trail]
+        body_long_total += arr_bl[i - 1] - arr_bl[body_long_trail]
+        equal_trail += 1
+        body_long_trail += 1
+
+
+def cdl_thrusting(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Thrusting"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_THRUSTING",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_tristar.py
+++ b/pandas_ta_classic/candles/cdl_tristar.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    body_doji_period = candle_avg_period(CandleSetting.BodyDoji)
+    lookback = body_doji_period + 2
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bd = ca._ranges[CandleSetting.BodyDoji]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    body_trail = start_idx - 2 - body_doji_period
+    body_total = float(arr_bd[body_trail : start_idx - 2].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i - 2] <= AVG_FACTOR[CandleSetting.BodyDoji] * body_total
+            and ca.real_body[i - 1] <= AVG_FACTOR[CandleSetting.BodyDoji] * body_total
+            and ca.real_body[i] <= AVG_FACTOR[CandleSetting.BodyDoji] * body_total
+        ):
+            if body_lo[i - 1] > body_hi[i - 2] and body_hi[i] < max(
+                ca.open[i - 1], ca.close[i - 1]
+            ):
+                out[i] = -100
+            if (
+                body_hi[i - 1] < body_lo[i - 2]
+                and min(ca.open[i], ca.close[i]) > body_lo[i - 1]
+            ):
+                out[i] = 100
+
+        body_total += arr_bd[i - 2] - arr_bd[body_trail]
+        body_trail += 1
+
+
+def cdl_tristar(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Tristar"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_TRISTAR",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_unique3river.py
+++ b/pandas_ta_classic/candles/cdl_unique3river.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    lookback = max(body_long_period, body_short_period) + 2
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+
+    body_long_trail = start_idx - 2 - body_long_period
+    body_short_trail = start_idx - body_short_period
+    body_long_total = float(arr_bl[body_long_trail : start_idx - 2].sum())
+    body_short_total = float(arr_bs[body_short_trail:start_idx].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.real_body[i - 2] > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.color[i - 2] == -1
+            and ca.color[i - 1] == -1
+            and ca.close[i - 1] > ca.close[i - 2]
+            and ca.open[i - 1] <= ca.open[i - 2]
+            and ca.low[i - 1] < ca.low[i - 2]
+            and ca.real_body[i] < AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            and ca.color[i] == 1
+            and ca.open[i] > ca.low[i - 1]
+        ):
+            out[i] = 100
+
+        body_long_total += arr_bl[i - 2] - arr_bl[body_long_trail]
+        body_short_total += arr_bs[i] - arr_bs[body_short_trail]
+        body_long_trail += 1
+        body_short_trail += 1
+
+
+def cdl_unique3river(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Unique Three River"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_UNIQUE3RIVER",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_upsidegap2crows.py
+++ b/pandas_ta_classic/candles/cdl_upsidegap2crows.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    AVG_FACTOR,
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    body_long_period = candle_avg_period(CandleSetting.BodyLong)
+    body_short_period = candle_avg_period(CandleSetting.BodyShort)
+    lookback = max(body_long_period, body_short_period) + 2
+    start_idx = lookback
+    if start_idx >= len(out):
+        return
+
+    arr_bl = ca._ranges[CandleSetting.BodyLong]
+    arr_bs = ca._ranges[CandleSetting.BodyShort]
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    body_long_trail = start_idx - 2 - body_long_period
+    body_short_trail = start_idx - 1 - body_short_period
+    body_long_total = float(arr_bl[body_long_trail : start_idx - 2].sum())
+    body_short_total = float(arr_bs[body_short_trail : start_idx - 1].sum())
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 2] == 1
+            and ca.real_body[i - 2]
+            > AVG_FACTOR[CandleSetting.BodyLong] * body_long_total
+            and ca.color[i - 1] == -1
+            and ca.real_body[i - 1]
+            <= AVG_FACTOR[CandleSetting.BodyShort] * body_short_total
+            and body_lo[i - 1] > body_hi[i - 2]
+            and ca.color[i] == -1
+            and ca.open[i] > ca.open[i - 1]
+            and ca.close[i] < ca.close[i - 1]
+            and ca.close[i] > ca.close[i - 2]
+        ):
+            out[i] = -100
+
+        body_long_total += arr_bl[i - 2] - arr_bl[body_long_trail]
+        body_short_total += arr_bs[i - 1] - arr_bs[body_short_trail]
+        body_long_trail += 1
+        body_short_trail += 1
+
+
+def cdl_upsidegap2crows(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Upside Gap Two Crows"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_UPSIDEGAP2CROWS",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/candles/cdl_xsidegap3methods.py
+++ b/pandas_ta_classic/candles/cdl_xsidegap3methods.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from typing import Any, Optional
+
+from pandas import Series
+
+from pandas_ta_classic.candles._cdl_math import (
+    CandleArrays,
+    CandleSetting,
+    candle_avg_period,
+    run_pattern,
+)
+import numpy as np
+
+
+def _detect(ca, out, **kwargs):
+    start_idx = 2
+    if start_idx >= len(out):
+        return
+
+    body_hi = ca.body_high
+    body_lo = ca.body_low
+
+    for i in range(start_idx, len(out)):
+        if (
+            ca.color[i - 2] == ca.color[i - 1]
+            and ca.color[i - 1] == -ca.color[i]
+            and ca.open[i] < body_hi[i - 1]
+            and ca.open[i] > body_lo[i - 1]
+            and ca.close[i] < body_hi[i - 2]
+            and ca.close[i] > body_lo[i - 2]
+            and (
+                (ca.color[i - 2] == 1 and body_lo[i - 1] > body_hi[i - 2])
+                or (ca.color[i - 2] == -1 and body_hi[i - 1] < body_lo[i - 2])
+            )
+        ):
+            out[i] = ca.color[i - 2] * 100
+
+
+def cdl_xsidegap3methods(
+    open_: Series,
+    high: Series,
+    low: Series,
+    close: Series,
+    scalar: Optional[float] = None,
+    offset: Optional[int] = None,
+    **kwargs: Any,
+) -> Optional[Series]:
+    """Candle Pattern: Upside/Downside Gap Three Methods"""
+    return run_pattern(
+        open_,
+        high,
+        low,
+        close,
+        _detect,
+        "CDL_XSIDEGAP3METHODS",
+        scalar=scalar,
+        offset=offset,
+        **kwargs,
+    )

--- a/pandas_ta_classic/core.py
+++ b/pandas_ta_classic/core.py
@@ -715,10 +715,11 @@ class AnalysisIndicators(BasePandasObject):
         # Possible to have other indicator main window lengths to be included
         removal = []
         for kwds in ta:
-            _ = False
-            if "length" in kwds and kwds["length"] > self._df.shape[0]:
-                _ = True
-            if _:
+            if (
+                isinstance(kwds, dict)
+                and "length" in kwds
+                and kwds["length"] > self._df.shape[0]
+            ):
                 removal.append(kwds)
         if len(removal) > 0:
             for x in removal:


### PR DESCRIPTION
## Summary
Add 59 native candlestick pattern implementations matching TA-Lib's CDL family. Each pattern is a standalone file in the `candles/` directory, accessible via `cdl_pattern(name=...)` or individually.

Includes:
- Shared `_cdl_math.py` helper with candle body/shadow calculations
- Updated `_meta.py` category discovery to filter sub-pattern files
- All 59 patterns: 2crows, 3blackcrows, 3inside, 3linestrike, 3outside, 3starsinsouth, 3whitesoldiers, abandonedbaby, advanceblock, belthold, breakaway, closingmarubozu, concealbabyswall, counterattack, darkcloudcover, dojistar, dragonflydoji, engulfing, eveningdojistar, eveningstar, gapsidesidewhite, gravestonedoji, hammer, hangingman, harami, haramicross, highwave, hikkake, hikkakemod, homingpigeon, identical3crows, inneck, invertedhammer, kicking, kickingbylength, ladderbottom, longleggeddoji, longline, marubozu, matchinglow, mathold, morningdojistar, morningstar, onneck, piercing, rickshawman, risefall3methods, separatinglines, shootingstar, shortline, spinningtop, stalledpattern, sticksandwich, takuri, tasukigap, thrusting, tristar, unique3river, upsidegap2crows, xsidegap3methods

## Test plan
- [x] `pytest` passes on Python 3.9–3.13
- [x] Each pattern matches TA-Lib output (where TA-Lib is installed)
- [x] `cdl_pattern(name="engulfing")` etc. dispatch correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)