### PR TITLE
perf(test): cache CSV parsing with lru_cache

### DIFF
--- a/tests/config.py
+++ b/tests/config.py
@@ -1,4 +1,5 @@
 import os
+from functools import lru_cache
 from pandas import read_csv
 
 VERBOSE = True
@@ -10,7 +11,8 @@ CORRELATION = "corr"  # "sem"
 CORRELATION_THRESHOLD = 0.99  # Less than 0.99 is undesirable
 
 
-def get_sample_data():
+@lru_cache(maxsize=1)
+def _read_sample_csv():
     df = read_csv(
         "data/SPY_D.csv",
         index_col="date",
@@ -18,6 +20,10 @@ def get_sample_data():
     )
     df.drop(columns=["Unnamed: 0"], inplace=True, errors="ignore")
     return df
+
+
+def get_sample_data():
+    return _read_sample_csv().copy()
 
 
 def error_analysis(df, kind, msg, icon=INFO, newline=True):


### PR DESCRIPTION
## Summary
- Wrap the CSV read in `@lru_cache` so the expensive `parse_dates` + `read_csv` call happens only once per test session
- Each test class still gets a fresh `.copy()` to prevent mutation leaks between tests
- Reduces test suite wall-clock time by avoiding redundant I/O

## Changes
- `tests/config.py`: Extract `_read_sample_csv()` with `@lru_cache(maxsize=1)`, `get_sample_data()` returns `.copy()`

## Test plan
- [x] `pytest` passes (435 passed)
- [x] No test isolation issues (each test gets independent DataFrame copy)
- [x] `black .` formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)