### PR TITLE
fix(core): ichimoku accessor returns DataFrame instead of tuple

### DIFF
--- a/docs/indicators.rst
+++ b/docs/indicators.rst
@@ -171,7 +171,7 @@ Moving averages and trend-following indicators:
 * *Hull Exponential Moving Average*: **hma**
 * *Hilbert Transform Instantaneous Trendline*: **ht_trendline**
 * *Holt-Winter Moving Average*: **hwma**
-* *Ichimoku Kinkō Hyō*: **ichimoku** (Returns two DataFrames. ``lookahead=False`` drops the Chikou Span Column)
+* *Ichimoku Kinkō Hyō*: **ichimoku** (The ``ta.ichimoku()`` function returns two DataFrames: the known-period Ichimoku DataFrame and a forward-looking Span DataFrame. The DataFrame Extension Method ``df.ta.ichimoku()`` returns a single DataFrame. ``lookahead=False`` drops the Chikou Span Column)
 * *Jurik Moving Average*: **jma**
 * *Kaufman's Adaptive Moving Average*: **kama**
 * *Linear Regression*: **linreg**

--- a/pandas_ta_classic/core.py
+++ b/pandas_ta_classic/core.py
@@ -2121,8 +2121,7 @@ class AnalysisIndicators(BasePandasObject):
         self._add_prefix_suffix(result, **kwargs)
         self._add_prefix_suffix(span, **kwargs)
         self._append(result, **kwargs)
-        # return self._post_process(result, **kwargs), span
-        return result, span
+        return self._post_process(result, **kwargs)
 
     def linreg(self, length=None, offset=None, adjust=None, **kwargs):
         close = self._get_column(kwargs.pop("close", "close"))

--- a/pandas_ta_classic/core.py
+++ b/pandas_ta_classic/core.py
@@ -540,10 +540,7 @@ class AnalysisIndicators(BasePandasObject):
     def _mp_worker(self, arguments: tuple):
         """Multiprocessing Worker to handle different Methods."""
         method, args, kwargs = arguments
-
-        if method != "ichimoku":
-            return getattr(self, method)(*args, **kwargs)
-        return getattr(self, method)(*args, **kwargs)[0]
+        return getattr(self, method)(*args, **kwargs)
 
     def _post_process(self, result, **kwargs) -> tuple[pd.Series, pd.DataFrame]:
         """Applies any additional modifications to the DataFrame

--- a/pandas_ta_classic/core.py
+++ b/pandas_ta_classic/core.py
@@ -252,9 +252,9 @@ class AnalysisIndicators(BasePandasObject):
 
     Returns:
         Most Indicators will return a Pandas Series. Others like MACD, BBANDS,
-        KC, et al will return a Pandas DataFrame. Ichimoku on the other hand
-        will return two DataFrames, the Ichimoku DataFrame for the known period
-        and a Span DataFrame for the future of the Span values.
+        KC, et al will return a Pandas DataFrame. Ichimoku returns a single
+        DataFrame for the known period; the forward-looking Span DataFrame is
+        only available through the underlying ``pandas_ta.ichimoku()`` function.
 
     Let's get started!
 
@@ -2116,7 +2116,6 @@ class AnalysisIndicators(BasePandasObject):
             **kwargs,
         )
         self._add_prefix_suffix(result, **kwargs)
-        self._add_prefix_suffix(span, **kwargs)
         self._append(result, **kwargs)
         return self._post_process(result, **kwargs)
 

--- a/tests/test_accessor_conformance.py
+++ b/tests/test_accessor_conformance.py
@@ -1,0 +1,35 @@
+from tests.config import get_sample_data
+
+from unittest import TestCase
+from pandas import DataFrame, Series
+
+
+class TestAccessorConformance(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = get_sample_data()
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.data
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_all_indicators_return_series_or_dataframe(self):
+        indicator_names = self.data.ta.indicators(as_list=True)
+        failures = []
+
+        for name in indicator_names:
+            try:
+                result = getattr(self.data.ta, name)()
+            except Exception:
+                continue
+
+            if not isinstance(result, (Series, DataFrame)):
+                failures.append(f"{name}: got {type(result).__name__}")
+
+        self.assertEqual(failures, [], f"Indicators returning wrong type: {failures}")


### PR DESCRIPTION
## Problem

`df.ta.ichimoku()` returns `(result, span)` — a `tuple[DataFrame, DataFrame]` — while every other multi-output accessor returns a plain `DataFrame`. This breaks strategy loops and any code expecting `Series | DataFrame` from the accessor pattern.

**Steps to reproduce:**
```python
import pandas as pd, numpy as np, pandas_ta_classic

df = pd.DataFrame({
    "open": np.random.rand(100) + 100,
    "high": np.random.rand(100) + 101,
    "low":  np.random.rand(100) + 99,
    "close": np.random.rand(100) + 100,
    "volume": np.random.rand(100) * 1000,
})

result = df.ta.ichimoku()
assert isinstance(result, pd.DataFrame), f"Expected DataFrame, got {type(result)}"
# AttributeError: 'tuple' object has no attribute 'columns'
```

## Root cause (two locations)

**1. `ichimoku` accessor (`core.py` ~line 2125)**

The accessor returned `(result, span)` and had the correct `_post_process` call commented out:

```python
# return self._post_process(result, **kwargs), span
return result, span
```

**2. `_mp_worker` (`core.py` ~line 544)**

The multiprocessing worker had an explicit special-case that indexed `[0]` off the accessor result to unwrap the tuple:

```python
if method != "ichimoku":
    return getattr(self, method)(*args, **kwargs)
return getattr(self, method)(*args, **kwargs)[0]  # KeyError: 0 after fix #1
```

After fixing the accessor, this `[0]` index on a plain `DataFrame` caused `KeyError: 0` in all strategy tests that dispatch ichimoku through the worker.

## Fix

**Accessor** — return only the main (visible-period) `DataFrame` via `_post_process`, consistent with all other indicators:

```python
return self._post_process(result, **kwargs)
```

**Worker** — remove the special-case branch entirely; ichimoku now flows through the same path as every other indicator:

```python
def _mp_worker(self, arguments: tuple):
    method, args, kwargs = arguments
    return getattr(self, method)(*args, **kwargs)
```

Users who need the forward-looking `span` DataFrame can call the underlying `ichimoku()` function directly with raw Series.

## Test plan

- [x] `test_ichimoku_ext` — accessor appends correct columns to `df`
- [x] `test_ichimoku` — underlying function unaffected (still returns tuple)
- [x] `test_strategy.py::TestStrategyMethods::test_overlap_category` — no more `KeyError: 0`
- [x] All strategy tests (`test_all`, `test_all_multiparams_strategy`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)