### PR TITLE
docs(statistics): document benchmark requirement in beta and correl

### DIFF
--- a/pandas_ta_classic/statistics/beta.py
+++ b/pandas_ta_classic/statistics/beta.py
@@ -4,6 +4,8 @@ from pandas import Series
 from pandas_ta_classic.utils import apply_fill, apply_offset, get_offset, verify_series
 
 
+# benchmark is Optional (not required) to stay compatible with df.ta.strategy("all"),
+# which calls every indicator without arguments; returns None when absent.
 def beta(
     close: Series,
     benchmark: Optional[Series] = None,

--- a/pandas_ta_classic/statistics/beta.py
+++ b/pandas_ta_classic/statistics/beta.py
@@ -4,8 +4,6 @@ from pandas import Series
 from pandas_ta_classic.utils import apply_fill, apply_offset, get_offset, verify_series
 
 
-# benchmark is Optional (not required) to stay compatible with df.ta.strategy("all"),
-# which calls every indicator without arguments; returns None when absent.
 def beta(
     close: Series,
     benchmark: Optional[Series] = None,
@@ -77,4 +75,5 @@ Kwargs:
 
 Returns:
     pd.Series: New feature generated.
+    None: If benchmark is not provided; enables df.ta.strategy("all") compatibility.
 """

--- a/pandas_ta_classic/statistics/correl.py
+++ b/pandas_ta_classic/statistics/correl.py
@@ -4,8 +4,6 @@ from pandas import Series
 from pandas_ta_classic.utils import apply_fill, apply_offset, get_offset, verify_series
 
 
-# benchmark is Optional (not required) to stay compatible with df.ta.strategy("all"),
-# which calls every indicator without arguments; returns None when absent.
 def correl(
     close: Series,
     benchmark: Optional[Series] = None,
@@ -70,4 +68,5 @@ Kwargs:
 
 Returns:
     pd.Series: New feature generated.
+    None: If benchmark is not provided; enables df.ta.strategy("all") compatibility.
 """

--- a/pandas_ta_classic/statistics/correl.py
+++ b/pandas_ta_classic/statistics/correl.py
@@ -4,6 +4,8 @@ from pandas import Series
 from pandas_ta_classic.utils import apply_fill, apply_offset, get_offset, verify_series
 
 
+# benchmark is Optional (not required) to stay compatible with df.ta.strategy("all"),
+# which calls every indicator without arguments; returns None when absent.
 def correl(
     close: Series,
     benchmark: Optional[Series] = None,


### PR DESCRIPTION
## Summary

- Docstring for `beta()` and `correl()`: clarifies that `benchmark` is required for a non-None result, but returns None when absent
- Code comment above both function signatures explains why `benchmark` stays `Optional[Series] = None`: making it a required positional argument breaks `df.ta.strategy("all")`, which calls every indicator without arguments

No code behavior changes.

## Why not a required parameter?

`df.ta.strategy("all")` iterates all indicators and calls each without arguments. Removing the default from `benchmark` raises:
```
TypeError: AnalysisIndicators.beta() missing 1 required positional argument: 'benchmark'
```
The `Optional` signature is intentional. Future options to enforce the requirement at runtime would be a separate PR (strategy exclusion or benchmark-aware runner).

## Test plan

- [x] `pytest tests/test_indicator_statistics.py tests/test_strategy.py` passes
- [x] `black .` no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)