### PR TITLE
docs(trend): clarify fast/slow as pre-computed Series; add xa/xb range guidance

### DIFF
--- a/pandas_ta_classic/trend/long_run.py
+++ b/pandas_ta_classic/trend/long_run.py
@@ -62,14 +62,21 @@ Calculation:
     LONG_RUN = PB OR BI
 
 Args:
-    fast (pd.Series): Fast moving average series
-    slow (pd.Series): Slow moving average series
+    fast (pd.Series): Fast moving average Series (e.g. EMA(5)). Pre-computed,
+        not a period length.
+    slow (pd.Series): Slow moving average Series (e.g. EMA(20)). Pre-computed,
+        not a period length.
     length (int): Lookback period. Default: 2
     offset (int): How many periods to offset the result. Default: 0
 
 Kwargs:
     fillna (value, optional): pd.DataFrame.fillna(value)
     fill_method (value, optional): Type of fill method
+
+Example:
+    fast_ma = df.ta.ema(length=5)
+    slow_ma = df.ta.ema(length=20)
+    lr = ta.long_run(fast_ma, slow_ma)
 
 Returns:
     pd.Series: New feature generated (boolean).

--- a/pandas_ta_classic/trend/short_run.py
+++ b/pandas_ta_classic/trend/short_run.py
@@ -60,14 +60,21 @@ Calculation:
     SHORT_RUN = PT OR BD
 
 Args:
-    fast (pd.Series): Fast moving average series
-    slow (pd.Series): Slow moving average series
+    fast (pd.Series): Fast moving average Series (e.g. EMA(5)). Pre-computed,
+        not a period length.
+    slow (pd.Series): Slow moving average Series (e.g. EMA(20)). Pre-computed,
+        not a period length.
     length (int): Lookback period. Default: 2
     offset (int): How many periods to offset the result. Default: 0
 
 Kwargs:
     fillna (value, optional): pd.DataFrame.fillna(value)
     fill_method (value, optional): Type of fill method
+
+Example:
+    fast_ma = df.ta.ema(length=5)
+    slow_ma = df.ta.ema(length=20)
+    sr = ta.short_run(fast_ma, slow_ma)
 
 Returns:
     pd.Series: New feature generated (boolean).

--- a/pandas_ta_classic/trend/xsignals.py
+++ b/pandas_ta_classic/trend/xsignals.py
@@ -94,12 +94,19 @@ Source: Kevin Johnson
 Calculation:
     Default Inputs:
         asbool=False, trend_reset=0, trade_offset=0, drift=1
+        (xa, xb: no defaults — required)
 
     trades = trends.diff().shift(trade_offset).fillna(0).astype(int)
     entries = (trades > 0).astype(int)
     exits = (trades < 0).abs().astype(int)
 
 Args:
+    signal (pd.Series): Oscillator or signal Series to evaluate.
+    xa (float): Entry threshold. Choose based on indicator range.
+        RSI/Stoch/KDJ (0–100): typical 20–30 (oversold) or 70–80 (overbought).
+        Unbounded indicators (MACD, CCI): must match their actual value range.
+        WARNING: xa=80 with MACD (range ~-5 to +5) will never trigger.
+    xb (float): Exit threshold, opposite side of xa (e.g. if xa=20 use xb=80).
     above (bool): When the signal crosses above 'xa' first and then 'xb'. When
         False, then when the signal crosses below 'xa' first and then 'xb'.
         Default: True


### PR DESCRIPTION
## Summary

- `long_run` / `short_run`: updated `fast` and `slow` Args to make explicit they expect pre-computed moving average Series, not integer period lengths; added `Example:` section showing typical usage with `df.ta.ema()`
- `xsignals`: added `signal`, `xa`, `xb` to the Args section (previously undocumented); `xa` includes range guidance and a warning for unbounded indicators (MACD, CCI); added `(xa, xb: no defaults — required)` to Default Inputs

No code changes.

## Test plan

- [x] `pytest tests/test_indicator_trend.py` passes
- [x] `black .` no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)