### PR TITLE
fix(momentum): eliminate silent double-fallback for KAMA/MAMA matypes in macdext

### DIFF
--- a/pandas_ta_classic/momentum/macdext.py
+++ b/pandas_ta_classic/momentum/macdext.py
@@ -16,8 +16,8 @@ _MATYPE_TO_KIND = {
     3: "dema",
     4: "tema",
     5: "trima",
-    6: "kama",
-    7: "mama",
+    6: "ema",  # KAMA not supported natively; EMA used as fallback
+    7: "ema",  # MAMA not supported natively; EMA used as fallback
     8: "t3",
 }
 
@@ -158,7 +158,8 @@ Like MACD but each of the three moving averages (fast, slow, signal) can use
 a different MA type, following the TA-Lib convention.
 
 MA type integers:
-    0=SMA, 1=EMA (default), 2=WMA, 3=DEMA, 4=TEMA, 5=TRIMA, 6=KAMA, 7=MAMA, 8=T3
+    0=SMA, 1=EMA (default), 2=WMA, 3=DEMA, 4=TEMA, 5=TRIMA, 6=KAMA*, 7=MAMA*, 8=T3
+    (* native fallback uses EMA; UserWarning emitted)
 
 Sources:
     TA-Lib: https://ta-lib.org/functions/
@@ -171,6 +172,9 @@ Args:
     fastmatype (int): MA type for fast line. Default: 1 (EMA).
     slowmatype (int): MA type for slow line. Default: 1 (EMA).
     signalmatype (int): MA type for signal line. Default: 1 (EMA).
+        Native fallback supports: 0=SMA, 1=EMA, 2=WMA, 3=DEMA, 4=TEMA,
+        5=TRIMA, 8=T3. Types 6=KAMA and 7=MAMA use EMA as a fallback and
+        emit a UserWarning. Use talib=True for correct KAMA/MAMA behaviour.
     talib (bool): Use TA-Lib if available. Default: False.
     offset (int): Number of periods to offset. Default: 0.
 

--- a/pandas_ta_classic/overlap/mavp.py
+++ b/pandas_ta_classic/overlap/mavp.py
@@ -124,7 +124,9 @@ Args:
     periods (pd.Series): Variable period series (optional). Default: linearly spaced [minperiod, maxperiod]
     minperiod (int): Minimum allowed period. Default: 2
     maxperiod (int): Maximum allowed period. Default: 30
-    mamode (int): MA type (TA-Lib convention: 0=SMA). Default: 0
+    mamode (int): MA type (TA-Lib convention). Default: 0 (SMA).
+        Only mamode=0 (SMA) is supported natively. All other values
+        require TA-Lib and emit a UserWarning if talib=False.
     talib (bool): Use TA-Lib if installed. Default: False
     offset (int): Result offset. Default: 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,9 @@ Documentation = "https://xgboosted.github.io/pandas-ta-classic/"
 markers = [
     "regression: snapshot regression tests — run with -m regression",
 ]
+filterwarnings = [
+    "error::UserWarning:pandas_ta_classic",
+]
 
 [tool.black]
 skip-string-normalization = true

--- a/tests/test_indicator_momentum.py
+++ b/tests/test_indicator_momentum.py
@@ -408,6 +408,17 @@ class TestMomentum(TestCase):
             ),
         )
 
+    def test_macdext_unsupported_matype_warns(self):
+        import pytest
+
+        with pytest.warns(UserWarning, match="EMA will be used instead"):
+            result = pandas_ta.macdext(self.close, signalmatype=6, talib=False)
+        self.assertIsInstance(result, DataFrame)
+
+        with pytest.warns(UserWarning, match="EMA will be used instead"):
+            result = pandas_ta.macdext(self.close, fastmatype=7, talib=False)
+        self.assertIsInstance(result, DataFrame)
+
     def test_mom(self):
         result = pandas_ta.mom(self.close, talib=False)
         if HAS_TALIB:

--- a/tests/test_indicator_overlap.py
+++ b/tests/test_indicator_overlap.py
@@ -320,6 +320,13 @@ class TestOverlap(TestCase):
             ),
         )
 
+    def test_mavp_unsupported_mamode_warns(self):
+        import pytest
+
+        with pytest.warns(UserWarning, match="Results will use SMA"):
+            result = pandas_ta.mavp(self.close, mamode=1, talib=False)
+        self.assertIsInstance(result, Series)
+
     def test_mcgd(self):
         assert_indicator_standard(
             self,


### PR DESCRIPTION
## Summary

- **Bug fix**: `_MATYPE_TO_KIND` mapped types 6 and 7 to `"kama"`/`"mama"`, but the native MA dispatcher doesn't support those — causing a silent second EMA fallback after the UserWarning. Changed to `{6: "ema", 7: "ema"}` so the warning is the only fallback path.
- **Docstrings**: `macdext` Args section now documents which matypes are supported natively (0–5, 8) vs fall back to EMA (6, 7); `mavp` mamode arg clarifies only `mamode=0` (SMA) is supported natively
- **CI hardening**: added `filterwarnings = ["error::UserWarning:pandas_ta_classic"]` to `[tool.pytest.ini_options]` — unexpected package-level warnings fail the test suite
- **New tests**:
  - `test_macdext_unsupported_matype_warns` — verifies `signalmatype=6` and `fastmatype=7` emit `UserWarning` matching "EMA will be used instead"
  - `test_mavp_unsupported_mamode_warns` — verifies `mamode=1` emits `UserWarning` matching "Results will use SMA"

## Test plan

- [x] `pytest tests/test_indicator_momentum.py -k macdext` — existing + new warning tests pass
- [x] `pytest tests/test_indicator_overlap.py -k mavp` — existing + new warning tests pass
- [x] `pytest tests/` — no unexpected UserWarnings from `pandas_ta_classic` raise errors
- [x] `black .` no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)