### PR TITLE
fix(cpr): rename open param to open_ so the accessor resolves it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **Unused hard dependencies**: `scipy`, `scikit-learn`, and `statsmodels` dropped from `[project.dependencies]` — nothing in the package imports them anymore. `_linear_regression_sklearn()` removed (see Changed). Stale `Imports` probes pruned (`backtrader`, `matplotlib`, `mplfinance`, `numba`, `scipy`, `sklearn`, `statsmodels`, `vectorbt`, `yaml`); numba acceleration is unaffected (`utils/_njit.py` self-detects numba).
 
 ### Fixed
+* **`cpr` accessor path silently returned the input frame**: the `open` input parameter was named `open` (bare) instead of the `open_` convention. The DataFrame accessor's generic column mapper only maps the `open_` param to the `open` column, so `df.ta.cpr()` never fetched open prices, `cpr()` returned `None`, and the accessor fell back to the unchanged input DataFrame. Renamed the parameter to `open_`; positional calls are unaffected.
 * **Cross-package indicator imports**: A submodule import could overwrite a re-exported function of the same name on the parent package (e.g. `from pandas_ta_classic.volatility import atr` occasionally returned the `atr` *module* instead of the function). Resolved.
 * **Test-fixture regen no longer drops `cmo_14` entries** when running tests without tulipy installed. Generators now merge with existing JSON instead of overwriting.
 

--- a/pandas_ta_classic/core.pyi
+++ b/pandas_ta_classic/core.pyi
@@ -564,7 +564,6 @@ class AnalysisIndicators:
     ) -> Optional[DataFrame]: ...
     def cpr(
         self,
-        open: Series,
         method: str = 'classic',
         timeframe: str = 'daily',
         interval: Optional[str] = None,

--- a/pandas_ta_classic/trend/cpr.py
+++ b/pandas_ta_classic/trend/cpr.py
@@ -71,7 +71,7 @@ def _cpr_build_dataframe(pivot_result, levels, width_analysis, price_position, v
 
 
 def cpr(
-    open: Series,
+    open_: Series,
     high: Series,
     low: Series,
     close: Series,
@@ -101,17 +101,17 @@ def cpr(
         levels = "standard"
 
     length = 1  # For verify_series
-    open = verify_series(open, length)
+    open_ = verify_series(open_, length)
     high = verify_series(high, length)
     low = verify_series(low, length)
     close = verify_series(close, length)
     offset = get_offset(offset)
 
-    if _any_none(open, high, low, close):
+    if _any_none(open_, high, low, close):
         return None
 
     # Prepare DataFrame for OHLCV processing
-    ohlcv_df = DataFrame({"open": open, "high": high, "low": low, "close": close})
+    ohlcv_df = DataFrame({"open": open_, "high": high, "low": low, "close": close})
     if volume is not None:
         ohlcv_df["volume"] = volume
 
@@ -383,7 +383,7 @@ Calculation:
         S2 = Pivot - (H - L)
 
 Args:
-    open (pd.Series): Series of 'open's
+    open_ (pd.Series): Series of 'open's
     high (pd.Series): Series of 'high's
     low (pd.Series): Series of 'low's
     close (pd.Series): Series of 'close's

--- a/tests/test_ext_indicator_trend.py
+++ b/tests/test_ext_indicator_trend.py
@@ -53,6 +53,14 @@ class TestTrendExtension(TestCase):
         self.assertIsInstance(self.data, DataFrame)
         self.assertEqual(list(self.data.columns[-2:]), ["CKSPl_10_1_9", "CKSPs_10_1_9"])
 
+    def test_cpr_ext(self):
+        # Regression: the generic accessor maps the open_ param to the 'open'
+        # column. A bare 'open' param made df.ta.cpr() silently return the
+        # unchanged input frame instead of computing CPR.
+        result = self.data.ta.cpr()
+        self.assertIsInstance(result, DataFrame)
+        self.assertIn("CPR_PIVOT", result.columns)
+
     def test_decay_ext(self):
         self.data.ta.decay(append=True)
         self.assertIsInstance(self.data, DataFrame)


### PR DESCRIPTION
## Problem
The `cpr` `open` input parameter was named `open` (bare) instead of the `open_` convention used across the codebase. The DataFrame accessor's generic column mapper (`_COLUMN_PARAM_TO_COL_KEY`) only maps the `open_` param to the `open` column, so `df.ta.cpr()` never fetched open prices: `cpr()` received `open=None`, returned `None`, and the accessor fell back to the unchanged input frame — the 11 CPR columns silently collapsed to the original OHLC 4.

Direct positional calls (`ta.cpr(o, h, l, c)`) were unaffected, which is why existing tests passed.

## Fix
- Rename the parameter to `open_` (function + docstring).
- Regenerate `core.pyi` (the accessor stub no longer carries a stray `open` param).
- Add `test_cpr_ext` asserting `CPR_PIVOT` is present in `df.ta.cpr()` output.

## Verification
- `df.ta.cpr()` now returns the full CPR DataFrame (11 cols) instead of the input frame.
- 17 cpr tests pass (positional + accessor); black + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)