### PR TITLE
fix(candles): remove dead no-op loop in cdl_counterattack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **Unused hard dependencies**: `scipy`, `scikit-learn`, and `statsmodels` dropped from `[project.dependencies]` — nothing in the package imports them anymore. `_linear_regression_sklearn()` removed (see Changed). Stale `Imports` probes pruned (`backtrader`, `matplotlib`, `mplfinance`, `numba`, `scipy`, `sklearn`, `statsmodels`, `vectorbt`, `yaml`); numba acceleration is unaffected (`utils/_njit.py` self-detects numba).
 
 ### Fixed
+* **`cdl_counterattack` dead loop removed**: an inner `for` loop evaluated a ternary expression and discarded it (ruff B018); the rolling-window updates on the following lines already carry the intended behavior. Output is unchanged.
 * **Cross-package indicator imports**: A submodule import could overwrite a re-exported function of the same name on the parent package (e.g. `from pandas_ta_classic.volatility import atr` occasionally returned the `atr` *module* instead of the function). Resolved.
 * **Test-fixture regen no longer drops `cmo_14` entries** when running tests without tulipy installed. Generators now merge with existing JSON instead of overwriting.
 

--- a/pandas_ta_classic/candles/cdl_counterattack.py
+++ b/pandas_ta_classic/candles/cdl_counterattack.py
@@ -53,8 +53,6 @@ def _detect(ca: CandleArrays, out: np.ndarray, **kwargs: Any) -> None:
             out[i] = ca.color[i] * 100
 
         equal_total += arr_eq[i - 1] - arr_eq[equal_trail - 1]
-        for totIdx in range(1, -1, -1):
-            body_long_total_1 if totIdx == 1 else body_long_total_0
         body_long_total_1 += arr_bl[i - 1] - arr_bl[body_long_trail - 1]
         body_long_total_0 += arr_bl[i] - arr_bl[body_long_trail]
         equal_trail += 1


### PR DESCRIPTION
## Change
An inner `for totIdx in range(1, -1, -1)` loop evaluated the ternary `body_long_total_1 if totIdx == 1 else body_long_total_0` and discarded the result (ruff **B018**, useless expression). The rolling-window updates on the following lines already carry the intended behavior, so the loop was pure dead code.

## Verification
- njit function still compiles; `cdl_pattern(name="counterattack")` output unchanged.
- Candle tests pass; black + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)