### PR TITLE
chore(deprecate): FutureWarning on constants(), get_time, EXCHANGE_TZ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **`optimal_leverage()` returns a float**: the result is no longer truncated with `int()`, the `capital` argument is documented, the unused `**kwargs` parameter is removed, and the "Incomplete. Do NOT use" docstring warning is removed. Zero-variance input now raises `ValueError` (previously crashed with `OverflowError`).
 
 ### Deprecated
+* **`df.ta.constants()`**: emits a `FutureWarning` and will be removed in a future release. Adding horizontal charting lines is out of scope for a technical-analysis library; assign the columns directly instead (e.g. `df["0"] = 0`).
+* **Top-level `pandas_ta_classic.get_time` and `pandas_ta_classic.EXCHANGE_TZ`**: emit a `FutureWarning` when accessed as public names and will be removed in a future release; wall-clock / exchange-timezone helpers are out of scope for a TA library. The functions still back the internal Strategy run-timer (imported from `pandas_ta_classic._meta` / `pandas_ta_classic.utils`), so normal indicator and Strategy usage is unaffected and warning-free.
 * **`CDL_PATTERN_NAMES`**: Use `ALL_PATTERNS` instead. Accessing the old name emits a `DeprecationWarning`.
 
 ### Removed

--- a/docs/dataframe_api.rst
+++ b/docs/dataframe_api.rst
@@ -190,6 +190,11 @@ constants
 ``constants(append: bool, values: list | np.ndarray)`` — adds or removes
 constant horizontal-line columns from the DataFrame.
 
+.. deprecated:: 0.6.53
+   ``df.ta.constants()`` is deprecated and will be removed in a future release;
+   adding horizontal charting lines is out of scope for a technical-analysis
+   library. Assign the columns directly instead, e.g. ``df["0"] = 0``.
+
 .. code-block:: python
 
     import numpy as np

--- a/pandas_ta_classic/__init__.py
+++ b/pandas_ta_classic/__init__.py
@@ -3,10 +3,12 @@ from typing import Any
 
 # Metadata comes from _meta to avoid circular imports; it must be imported
 # before core/utils because submodules read Imports off this package.
+# EXCHANGE_TZ is intentionally NOT imported here: it is deprecated as a public
+# top-level name and served lazily (with a FutureWarning) via __getattr__.
+# Internal callers import it directly from pandas_ta_classic._meta.
 from pandas_ta_classic._meta import (
     CANGLE_AGG,
     Category,
-    EXCHANGE_TZ,
     Imports,
     RATE,
     version,
@@ -39,7 +41,6 @@ from pandas_ta_classic.utils import (
     final_time,
     get_drift,
     get_offset,
-    get_time,
     is_datetime_ordered,
     is_percent,
     jensens_alpha,
@@ -90,7 +91,6 @@ __all__ = [
     "CANGLE_AGG",
     "Category",
     "CommonStrategy",
-    "EXCHANGE_TZ",
     "Imports",
     "RATE",
     "Strategy",
@@ -115,7 +115,6 @@ __all__ = [
     "final_time",
     "get_drift",
     "get_offset",
-    "get_time",
     "is_datetime_ordered",
     "is_percent",
     "jensens_alpha",
@@ -193,6 +192,8 @@ def __getattr__(name: str) -> Any:
         return ALL_PATTERNS
 
     # CDL_PATTERN_NAMES: deprecated alias — use ALL_PATTERNS
+    # Not cached via setattr: caching would resolve future lookups directly off
+    # the module dict, bypassing __getattr__ (and the warning) after first use.
     if name == "CDL_PATTERN_NAMES":
         import warnings
 
@@ -203,8 +204,30 @@ def __getattr__(name: str) -> Any:
         )
         from pandas_ta_classic.candles.cdl_pattern import ALL_PATTERNS
 
-        setattr(sys.modules[__name__], name, ALL_PATTERNS)
         return ALL_PATTERNS
+
+    # get_time / EXCHANGE_TZ: deprecated as public top-level names. These are
+    # wall-clock / exchange-timezone helpers unrelated to computing indicators;
+    # they remain available (internally used by the Strategy run timer) but the
+    # public exports emit a FutureWarning. Internal code imports them from
+    # pandas_ta_classic._meta / pandas_ta_classic.utils directly (no warning).
+    # Not cached via setattr, same reason as CDL_PATTERN_NAMES above — the
+    # warning must fire on every access, not just the first.
+    if name in ("get_time", "EXCHANGE_TZ"):
+        import warnings
+
+        warnings.warn(
+            f"pandas_ta_classic.{name} is deprecated and will be removed in a "
+            "future release; time/exchange-clock helpers are out of scope for a "
+            "technical-analysis library.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        if name == "get_time":
+            from pandas_ta_classic.utils import get_time as _obj
+        else:
+            from pandas_ta_classic._meta import EXCHANGE_TZ as _obj
+        return _obj
 
     # Individual candle-pattern submodules (cdl_*) not tracked in Category
     # → return the submodule (mimics old `from candles import *` behaviour)

--- a/pandas_ta_classic/core.py
+++ b/pandas_ta_classic/core.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from multiprocessing import cpu_count, get_context
 from time import perf_counter
 from typing import Any, Optional
-from warnings import simplefilter
+from warnings import simplefilter, warn
 
 import pandas as pd
 import numpy as np
@@ -519,6 +519,14 @@ class AnalysisIndicators(PandasObject):
             Returns nothing to the user.  Either adds or removes constant ranges
             from the working DataFrame.
         """
+        warn(
+            "df.ta.constants() is deprecated and will be removed in a future "
+            "release; adding horizontal charting lines is out of scope for a "
+            "technical-analysis library. Assign the columns directly, e.g. "
+            "df['0'] = 0.",
+            FutureWarning,
+            stacklevel=2,
+        )
         if isinstance(values, (np.ndarray, list)):
             if append:
                 for x in values:


### PR DESCRIPTION
These helpers are out of scope for a technical-analysis library and are now deprecated ahead of removal in a future release:

- df.ta.constants() (charting horizontal-line columns) warns at call time.
- Top-level pandas_ta_classic.get_time and pandas_ta_classic.EXCHANGE_TZ warn when accessed as public names, served lazily via the package __getattr__.

get_time / EXCHANGE_TZ still back the internal Strategy run-timer and exchange validation (imported directly from _meta / utils), so normal indicator and Strategy usage stays warning-free — verified: Strategy() construction emits no FutureWarning.

Update CHANGELOG and dataframe_api docs.