### PR TITLE
docs: update for data-fetching deprecation and frozen tulipy oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,16 @@ Using `uv`:
 git clone https://github.com/xgboosted/pandas-ta-classic.git
 cd pandas-ta-classic
 
-# Install with all dependencies
+# Install with all core dependencies (excludes the platform-fragile
+# data/backtest extras — install those explicitly if needed)
 uv pip install -e ".[all]"
 
 # Or install specific dependency groups:
 uv pip install -e ".[dev]" # Development tools
 uv pip install -e ".[optional]" # Optional runtime features
-uv pip install -e ".[oracle]" # Oracle parity libs: TA-Lib + tulipy
+uv pip install -e ".[oracle]" # Oracle parity lib: TA-Lib
+uv pip install -e ".[data]" # Data sources: yfinance, alpha-vantage
+uv pip install -e ".[backtest]" # Backtesting: backtesting, vectorbt, backtrader
 ```
 
 Using `pip`:
@@ -107,13 +110,16 @@ Using `pip`:
 git clone https://github.com/xgboosted/pandas-ta-classic.git
 cd pandas-ta-classic
 
-# Install with all dependencies
+# Install with all core dependencies (excludes the platform-fragile
+# data/backtest extras — install those explicitly if needed)
 pip install -e ".[all]"
 
 # Or install specific dependency groups:
 pip install -e ".[dev]" # Development tools
 pip install -e ".[optional]" # Optional runtime features
-pip install -e ".[oracle]" # Oracle parity libs: TA-Lib + tulipy
+pip install -e ".[oracle]" # Oracle parity lib: TA-Lib
+pip install -e ".[data]" # Data sources: yfinance, alpha-vantage
+pip install -e ".[backtest]" # Backtesting: backtesting, vectorbt, backtrader
 ```
 
 ### Basic Usage
@@ -124,8 +130,10 @@ import pandas_ta_classic as ta
 
 # Load your data
 df = pd.read_csv("path/to/symbol.csv")
-# OR if you have yfinance installed
-df = df.ta.ticker("aapl")
+# OR fetch OHLCV with yfinance directly (df.ta.ticker() is deprecated —
+# see examples/fetch_market_data.py):
+# import yfinance as yf
+# df = yf.download("AAPL", period="1y")
 
 # Calculate indicators
 df.ta.sma(length=20, append=True) # Simple Moving Average
@@ -151,7 +159,7 @@ df.ta.strategy("CommonStrategy") # Runs commonly used indicators
 - **Fluent API Chaining**: ``df.ta.chain().sma(20).ta.rsi(14).ta.macd().ta.bbands(20)`` — chain multiple indicators in a single expression
 - **Pandas DataFrame Extension** for seamless integration (`df.ta.indicator()`)
 - **TA-Lib Integration (dual-role)** - **(1) acceleration backend**: core indicators use native implementations by default; pass `talib=True` to use TA-Lib's C implementation. **(2) oracle**: `test_oracle_talib.py` verifies parity against TA-Lib
-- **tulipy Integration (oracle only)** - parity test oracle; `test_oracle_tulipy.py` verifies native output against tulipy; never used as computation backend
+- **tulipy Integration (frozen oracle only)** - `test_oracle_tulipy.py` verifies native output against a committed golden snapshot of tulipy's output (`tests/fixtures/tulipy_oracle.json`); tulipy itself is no longer installed at test time, only to regenerate the snapshot; never used as a computation backend
 - **Backtesting.py Integration** — bridge function and runnable SMA crossover example in ``examples/backtesting_py_strategy.py``
 - **backtrader Integration** — precompute-then-feed pattern with dynamic `PandasData` subclass; runnable example in ``examples/backtrader_strategy.py``
 - **Vectorbt Integration** - compatible with popular backtesting framework
@@ -185,8 +193,8 @@ df.ta.strategy("CommonStrategy") # Runs commonly used indicators
 
 | Library | Role | Effect when installed |
 |---------|------|-----------------------|
-| TA-Lib | **Acceleration backend + oracle** | Core indicators — native by default, opt-in via `talib=True`; also used in `test_oracle_talib.py` for parity checks |
-| tulipy | **Oracle only** | Never used as computation backend; only `test_oracle_tulipy.py` uses it to verify native output |
+| TA-Lib | **Acceleration backend + live oracle** | Core indicators — native by default, opt-in via `talib=True`; also used live in `test_oracle_talib.py` for parity checks |
+| tulipy | **Frozen oracle only** | Not a computation backend and not installed at test time; `test_oracle_tulipy.py` compares against a committed golden snapshot of tulipy's output. tulipy is only needed to *regenerate* that snapshot (CPython <3.12) |
 
 | Area | Behaviour without TA-Lib | Behaviour with TA-Lib |
 |------|--------------------------|----------------------|
@@ -206,16 +214,16 @@ df.ta.ema(length=20, talib=True) # use TA-Lib
 Installing oracle libraries:
 ```bash
 # uv
-uv pip install pandas-ta-classic[oracle] # installs both TA-Lib and tulipy
+uv pip install pandas-ta-classic[oracle] # installs TA-Lib (the live oracle)
 uv pip install TA-Lib # TA-Lib only (also enables acceleration backend)
-uv pip install tulipy # tulipy only (oracle test use only)
 # pip
-pip install pandas-ta-classic[oracle] # installs both TA-Lib and tulipy
+pip install pandas-ta-classic[oracle] # installs TA-Lib (the live oracle)
 pip install TA-Lib # TA-Lib only (also enables acceleration backend)
-pip install tulipy # tulipy only (oracle test use only)
+# tulipy is only needed to regenerate the frozen oracle snapshot (CPython <3.12):
+pip install tulipy && python tests/fixtures/generate_tulipy_oracle.py
 ```
 
-> **Note:** Both oracle test suites (`test_oracle_talib.py`, `test_oracle_tulipy.py`) are guarded with `@unittest.skipUnless` and skip automatically when the respective library is not installed. Neither is required for normal use. Installing TA-Lib additionally enables C-library acceleration for core indicators via `talib=True`.
+> **Note:** `test_oracle_talib.py` skips automatically (`@unittest.skipUnless`) when TA-Lib is not installed. `test_oracle_tulipy.py` runs on every Python version against the committed `tulipy_oracle.json` snapshot (skips only if that fixture is missing) — it does **not** require tulipy installed. Neither is required for normal use. Installing TA-Lib additionally enables C-library acceleration for core indicators via `talib=True`.
 
 **Performance boost:** Install `numba` for 6–230× speedups on computation-heavy indicators:
 - Using `uv`: `uv pip install pandas-ta-classic[performance]`

--- a/docs/dataframe_api.rst
+++ b/docs/dataframe_api.rst
@@ -228,13 +228,22 @@ indicators
 ticker
 ~~~~~~
 
+.. deprecated:: 0.6.53
+   ``df.ta.ticker()`` (and ``ta.yf()`` / ``ta.av()``) is deprecated and will be
+   removed in a future release; data fetching is out of scope for a
+   technical-analysis library. It emits a ``FutureWarning``. Fetch OHLCV with
+   yfinance / alpha-vantage directly and pass the DataFrame to pandas-ta-classic
+   — see ``examples/fetch_market_data.py`` for the replacement patterns.
+
 .. code-block:: python
 
-    # Download stock data (requires yfinance)
+    # Deprecated — emits FutureWarning (requires the [data] extra)
     df = df.ta.ticker("AAPL")
-    
-    # With period and interval
-    df = df.ta.ticker("AAPL", period="1y", interval="1d")
+
+    # Preferred: fetch with yfinance directly, then use pandas-ta-classic
+    import yfinance as yf
+    df = yf.download("AAPL", period="1y", interval="1d")
+    df.ta.rsi(append=True)
 
 chain
 ~~~~~

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,9 +19,9 @@ Optional Dependencies
 For enhanced functionality, consider installing:
 
 - **TA-Lib**: Optional — all 62 CDL patterns work natively without it (see :ref:`Installing TA-Lib` below)
-- **tulipy**: Optional — oracle-only; used by ``test_oracle_tulipy.py`` for parity verification, never as a computation backend
-- **yfinance**: For downloading stock data with ``df.ta.ticker()``
-- **vectorbt**: For backtesting integration
+- **tulipy**: Optional — only needed to *regenerate* the frozen oracle golden file (``tests/fixtures/generate_tulipy_oracle.py`` on CPython <3.12); ``test_oracle_tulipy.py`` compares against the committed snapshot and no longer imports tulipy at test time
+- **yfinance / alpha-vantage**: For downloading OHLCV data (``pip install pandas-ta-classic[data]``). Note: the built-in ``df.ta.ticker()`` / ``ta.yf()`` / ``ta.av()`` helpers are deprecated — call yfinance / alpha-vantage directly and pass the DataFrame in (see ``examples/fetch_market_data.py``)
+- **vectorbt / backtrader / backtesting**: For backtesting integration (``pip install pandas-ta-classic[backtest]``)
 - **pytest + Hypothesis**: For running the test suite and property-based tests (``pip install pandas-ta-classic[test]``)
 
 Installation Methods

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -157,11 +157,10 @@ print(df.tail())
 import pandas as pd
 import pandas_ta_classic as ta
 
-# Create empty DataFrame
-df = pd.DataFrame()
-
-# Fetch data (requires yfinance)
-df = df.ta.ticker("AAPL", period="1y")
+# Fetch data with yfinance directly (df.ta.ticker() is deprecated —
+# see examples/fetch_market_data.py)
+import yfinance as yf
+df = yf.download("AAPL", period="1y")
 
 # Add indicators
 df.ta.sma(length=20, append=True)
@@ -447,7 +446,7 @@ Now that you've got the basics, explore more:
 | Custom strategy | `ta.Strategy(name="My", ta=[...])` |
 | List categories | `print(ta.Category)` |
 | Get help | `help(ta.sma)` |
-| Fetch data | `df.ta.ticker("AAPL")` |
+| Fetch data | `yf.download("AAPL")` (via yfinance; `df.ta.ticker()` deprecated) |
 
 ## Need Help?
 


### PR DESCRIPTION
## Summary

Documentation had drifted from code after the optional-dependency cleanup and oracle rework merged this cycle. Two families of stale statements, fixed here:

1. **Data-fetching helpers presented as normal usage.** `df.ta.ticker()` / `ta.yf()` / `ta.av()` are deprecated (emit `FutureWarning`), but README, `quickstart.md`, `dataframe_api.rst`, and `installation.rst` still showed them as the standard way to load data. Replaced with the yfinance-direct pattern and a deprecation note pointing to `examples/fetch_market_data.py`.

2. **tulipy described as a live test-time oracle.** It was frozen to a committed golden snapshot (`tests/fixtures/tulipy_oracle.json`) and is no longer installed at test time. Corrected the README oracle table / install commands / feature list and `installation.rst`: TA-Lib is the live oracle; `test_oracle_tulipy.py` runs against the snapshot on every Python version; tulipy is only needed to *regenerate* it (CPython <3.12).

Also: added `[data]` / `[backtest]` install lines and noted that `[all]` no longer pulls them.

## Not changed (verified already accurate)
- `indicator_support_matrix.rst` — the 13 TA-Lib-passthrough indicators already show TA-Lib=yes (the matrix tracks TA-Lib capability, which predates the passthrough).
- `constants()` deprecation — already noted in `dataframe_api.rst`.
- No stale `ichimoku` tuple-unpack, bare-`open` cpr, or `[integration]` extra references remain.

## Verification
- Sphinx build clean (only the pre-existing benign `html_static_path` warning).
- Every factual claim cross-checked against code: `test_oracle_tulipy.py` skip condition (`skipUnless` fixture-present), `pyproject.toml` extras, fixture/generator paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)