### PR TITLE
docs(quickstart): explain all-NaN results on gapped/resampled data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * **Cross-package indicator imports**: A submodule import could overwrite a re-exported function of the same name on the parent package (e.g. `from pandas_ta_classic.volatility import atr` occasionally returned the `atr` *module* instead of the function). Resolved.
 * **Test-fixture regen no longer drops `cmo_14` entries** when running tests without tulipy installed. Generators now merge with existing JSON instead of overwriting.
 
+### Documentation
+* **Quickstart troubleshooting: all-NaN results after resampling** (`docs/quickstart.md`): a NaN row *inside* the series — what `df.resample('D')` inserts for every weekend on a weekday-only feed — is a different failure from having too little data, and the existing entry pointed at the wrong diagnosis. 81 of 224 indicators return all-`NaN` on a 300-row daily frame with weekend gaps (`sma`, `stoch`, `macd`, `linreg`, `willr`, `stdev` among them) while `ema`, `rma` and `atr` still produce values, because a `rolling(length)` window needs `length` consecutive non-NaN bars and an `ewm` recursion does not. Documents the asymmetry and the fix (`dropna()` the resampled frame before computing, and assign the result back).
+
 ## [0.6.52] - 2026-06-25
 
 ### Added

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -404,6 +404,31 @@ if len(df) >= 20:
  df.ta.sma(length=20, append=True)
 ```
 
+### Issue: "All NaN values" after resampling
+
+**Cause:** A gap *inside* the series, rather than too little data. `df.resample('D')` on a
+feed that only trades on weekdays inserts a NaN row for every weekend, and many indicators
+cannot see past those rows. On a 300-row daily frame with weekend gaps, 81 of 224 indicators
+return all-NaN — among them `sma`, `stoch`, `macd`, `linreg`, `willr` and `stdev` — while
+`ema`, `rma` and `atr` still produce values.
+
+Which side an indicator falls on depends on its internals: a `rolling(length)` window needs
+`length` consecutive non-NaN bars, an `ewm` recursion does not. So two indicators called with
+the same `length` can legitimately start at different bars on gapped data.
+
+**Solution:** Drop the empty periods before computing, not after:
+
+```python
+# resample() emits one row per calendar period, gap or not
+daily = df.resample('D').agg({'open': 'first', 'high': 'max',
+                              'low': 'min', 'close': 'last'})
+
+daily = daily.dropna()  # drop the empty periods first
+daily.ta.sma(length=14, append=True)
+```
+
+`dropna()` returns a copy, so `daily.dropna()` on a line of its own does nothing — assign it back.
+
 ### Issue: "Import Error: No module named 'pandas_ta_classic'"
 
 **Solution:** Verify installation:


### PR DESCRIPTION
Docs only. Independent of #145, #146 and #147.

The Quickstart troubleshooting entry "All NaN values" blames insufficient data, which is the wrong diagnosis for the more common case: a NaN row *inside* the series. `df.resample('D')` on a weekday-only feed inserts one for every weekend, and many indicators cannot see past it.

## What the new entry documents

Measured on a 300-row daily frame with weekend gaps: **81 of 224 indicators return all-`NaN`** — `sma`, `stoch`, `macd`, `linreg`, `willr`, `stdev` among them — while `ema`, `rma` and `atr` still produce values.

The split follows the mechanism, not the indicator family: a `rolling(length)` window needs `length` consecutive non-NaN bars, an `ewm` recursion does not. So two indicators called with the same `length` can legitimately start at different bars on gapped data. Worth noting that `macd` is `ewm`-based and still goes all-`NaN`, because it seeds its own TA-Lib-compatible EMA (`_ema_aligned`) rather than calling `ema()` — which is why the entry explains the mechanism instead of listing "safe" indicators.

This is what [kernc/backtesting.py#1243](https://github.com/kernc/backtesting.py/issues/1243) ran into: SMA and ATR resampled to the same daily rule with the same `length=14`, plotted from visibly different start bars, and the reporter could not tell whether it was their code or the library. That thread also shows the second half of the trap — `df_resampled.dropna()` on a line of its own, result discarded — so the entry calls that out too.

## Verification

The documented example was run, not just written:

```
resampled rows: 30  NaN rows: 8
without dropna -> SMA_14 valid values: 0
with dropna    -> rows: 22  SMA_14 valid values: 9
```

`sphinx -b html` builds clean (exit 0); the only warnings are pre-existing `docs/dev/` files outside any toctree.

No library code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
