### PR TITLE
ci(git): merge CHANGELOG.md with the union driver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Every PR appends bullets under the [Unreleased] heading, so any two open PRs
+# touch the same lines and conflict there by construction. `union` keeps both
+# sides instead of stopping the merge.
+#
+# It is not free. A PR that *edits* an existing bullet rather than appending a
+# new one gets both the old and the new line, which lands as a visible duplicate
+# instead of a conflict. Read the [Unreleased] section after merging anything
+# that rewrote existing entries.
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+* **`.gitattributes` with `CHANGELOG.md merge=union`**: concurrent pull requests each append a bullet under `[Unreleased]`, so every pair of open PRs conflicted on this file by construction. The union merge driver keeps both sides. A PR that rewrites an existing bullet now produces a duplicate line rather than a conflict, so review `[Unreleased]` after merging one of those.
 * **backtesting.py integration** (PR #124 by @Adhyansinghgupta): Bridge function (`ta_bridge`), `SMACrossover` example strategy (`examples/backtesting_py_strategy.py`), and integration tutorial (`docs/tutorials/backtesting_py.md`). Added `backtesting` to `integration` optional dependencies.
 * **backtrader integration** (`docs/tutorials/backtrader.md`, `examples/backtrader_strategy.py`): Precompute-then-feed pattern using dynamic `PandasData` subclass (`make_feed()`); covers single-output, multi-output (MACD), and OHLCV-dependent (ATR) indicators. Added `backtrader` to `integration` optional dependencies.
 * **vectorbt integration tutorial** (`docs/tutorials/vectorbt.md`): Documented the `df.ta.tsignals()` → `vbt.Portfolio.from_signals()` integration pattern, including multi-output indicator handling and benchmark comparison.


### PR DESCRIPTION
Every pull request adds a bullet under the `[Unreleased]` heading. That puts each one on the same lines as every other open pull request, so essentially any two of them conflict on `CHANGELOG.md`. The conflict carries no information: both sides are additions, and both are wanted.

This adds a `.gitattributes` marking the file `merge=union`, so git keeps both sides.

### Measured against the currently open pull requests

Merging the nine open pull requests one after another onto `main`:

| | conflicts | of those, `CHANGELOG.md` only |
|---|---|---|
| before | 5 of 9 | 4 |
| after | 3 of 9 | 0 |

The three that remain are real and unrelated — two on `tests/fixtures/regression_snapshots.json` (a generated file; the resolution is to re-run the generator, never to pick a side) and one on an import block in `tests/test_accessor_api.py`.

### The caveat

`union` is not free, and `.gitattributes` records this next to the rule: a pull request that *rewrites* an existing bullet rather than appending a new one ends up with both the old line and the new one. That surfaces as a visible duplicate instead of a conflict, so `[Unreleased]` is worth a look after merging anything that edited existing entries.

Two of the currently open pull requests do edit existing bullets. Neither produced a duplicate in the run above, because no other pull request touched the same lines — but the property is real, not hypothetical.
