### PR TITLE
docs(examples): add manifoldbt integration guide and example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+* **manifoldbt integration** (`docs/tutorials/manifoldbt.md`, `examples/manifoldbt_strategy.py`): Precompute-then-register pattern that passes pandas-ta-classic output to the engine as an exogenous series (`register_exo()` / `exo()`); covers single-output, multi-output (MACD) and OHLCV-dependent (ATR) indicators. Added `manifoldbt` to `backtest` optional dependencies.
 * **backtesting.py integration** (PR #124 by @Adhyansinghgupta): Bridge function (`ta_bridge`), `SMACrossover` example strategy (`examples/backtesting_py_strategy.py`), and integration tutorial (`docs/tutorials/backtesting_py.md`). Added `backtesting` to `integration` optional dependencies.
 * **backtrader integration** (`docs/tutorials/backtrader.md`, `examples/backtrader_strategy.py`): Precompute-then-feed pattern using dynamic `PandasData` subclass (`make_feed()`); covers single-output, multi-output (MACD), and OHLCV-dependent (ATR) indicators. Added `backtrader` to `integration` optional dependencies.
 * **vectorbt integration tutorial** (`docs/tutorials/vectorbt.md`): Documented the `df.ta.tsignals()` → `vbt.Portfolio.from_signals()` integration pattern, including multi-output indicator handling and benchmark comparison.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This is the **classic/community maintained version** of the popular pandas-ta li
  - Integrating with backtesting.py
  - Integrating with backtrader
  - Integrating with VectorBT
+ - Integrating with manifoldbt
  - Multi-Timeframe Analysis
  - Creating Custom Indicators
  - Candlestick Pattern Recognition
@@ -163,6 +164,7 @@ df.ta.strategy("CommonStrategy") # Runs commonly used indicators
 - **Backtesting.py Integration** — bridge function and runnable SMA crossover example in ``examples/backtesting_py_strategy.py``
 - **backtrader Integration** — precompute-then-feed pattern with dynamic `PandasData` subclass; runnable example in ``examples/backtrader_strategy.py``
 - **Vectorbt Integration** - compatible with popular backtesting framework
+- **manifoldbt Integration** - precompute-then-register pattern using exogenous series; runnable example in ``examples/manifoldbt_strategy.py``
 - **Custom Indicators** - easily create and chain your own indicators
 
 ## Documentation

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -13,6 +13,7 @@ Step-by-step tutorials for common workflows with **Pandas TA Classic**.
 - [Tutorial 7: Multi-Timeframe Analysis](#tutorial-7-multi-timeframe-analysis)
 - [Tutorial 8: Creating Custom Indicators](#tutorial-8-creating-custom-indicators)
 - [Tutorial 9: Candlestick Pattern Recognition](#tutorial-9-candlestick-pattern-recognition)
+- [Tutorial 10: Integrating with manifoldbt](#tutorial-10-integrating-with-manifoldbt)
 
 ```{toctree}
 :hidden:
@@ -21,6 +22,7 @@ Step-by-step tutorials for common workflows with **Pandas TA Classic**.
 tutorials/backtesting_py
 tutorials/backtrader
 tutorials/vectorbt
+tutorials/manifoldbt
 ```
 
 ---
@@ -806,6 +808,15 @@ plt.show()
 - Combine patterns with momentum indicators
 - Backtest pattern effectiveness on your specific instrument
 - All 62 candlestick patterns are natively implemented (TA-Lib optional for selected core indicators)
+
+---
+
+(tutorial-10-integrating-with-manifoldbt)=
+## Tutorial 10: Integrating with manifoldbt
+
+Use pandas-ta-classic by precomputing indicators and registering them as an exogenous series.
+
+See the complete **[manifoldbt integration guide](tutorials/manifoldbt)** for a full walkthrough and runnable example (`examples/manifoldbt_strategy.py`).
 
 ---
 

--- a/docs/tutorials/manifoldbt.md
+++ b/docs/tutorials/manifoldbt.md
@@ -1,0 +1,118 @@
+# Integrating pandas-ta-classic with manifoldbt
+
+`manifoldbt` is a backtesting engine with a Rust core and a Python API. Strategies are written as expressions over whole columns (`when(fast > slow, 1.0, 0.0)`) rather than as a `next()` callback, and the engine evaluates them over a bar store it owns. Because it never hands you a per-bar Python hook, `pandas-ta-classic` integrates through a **precompute-then-register** pattern: indicators are computed over the full Series, then registered as an *exogenous series* the engine ASOF-joins onto the bars.
+
+```bash
+pip install manifoldbt
+```
+
+---
+
+## 1. The Integration Pattern
+
+1. Compute indicators over the full DataFrame with pandas-ta-classic.
+2. Collect them into a DataFrame carrying a `timestamp` column, and drop the warmup rows.
+3. Register that frame with `register_exo()`.
+4. Reference the columns in expressions with `exo("<series>", "<column>")`, and list the series in `BacktestConfig(exo_data=[...])`.
+
+```python
+import manifoldbt as mbt
+import pandas_ta_classic as ta
+from manifoldbt.expr import col, exo, lit, when
+
+# Step 1 - precompute over the full Series
+signals = pd.DataFrame(
+    {
+        'timestamp': df['timestamp'],
+        'sma_fast': ta.sma(df['close'], length=10),
+        'sma_slow': ta.sma(df['close'], length=20),
+    }
+).dropna()
+
+# Step 2 - the engine needs a bar store; a DataFrame can be imported directly
+store = mbt.import_dataframe(df, symbol='SYNTH', symbol_id=1, interval='1d', exchange='dataframe')
+
+# Step 3 - hand the indicators over as an exogenous series
+mbt.register_exo('pandas_ta', signals, store=store)
+
+# Step 4 - reference them in an expression
+position = when(exo('pandas_ta', 'sma_fast') > exo('pandas_ta', 'sma_slow'), lit(1.0), lit(0.0))
+strategy = mbt.Strategy.create('sma-crossover').signal('pos', position).size(col('pos'))
+```
+
+The bar DataFrame passed to `import_dataframe()` needs lowercase `timestamp,open,high,low,close,volume` columns, and the timestamps must be timezone-aware.
+
+> **Why register instead of feeding a column?** The engine loads its bars from its own store, so an extra column on the input DataFrame is not visible to expressions. An exogenous series is the supported channel for values computed elsewhere. It is ASOF-joined and forward-filled onto bar timestamps, which is also what makes it safe to register a frame that is shorter than the bar history.
+
+---
+
+## 2. Common Integration Patterns
+
+### Pattern A: Single-Output Indicators
+
+Single-output indicators (SMA, RSI, EMA) return one Series. Give each one a column in the exo frame.
+
+```python
+signals = pd.DataFrame(
+    {
+        'timestamp': df['timestamp'],
+        'rsi': ta.rsi(df['close'], length=14),
+    }
+).dropna()
+
+mbt.register_exo('pandas_ta', signals, store=store)
+position = when(exo('pandas_ta', 'rsi') < lit(30.0), lit(1.0), lit(0.0))
+```
+
+### Pattern B: Multi-Output Indicators (MACD, Bollinger Bands)
+
+Multi-output indicators return a DataFrame whose column names carry the parameters (`ta.macd(...)` gives `MACD_12_26_9`, `MACDh_12_26_9`, `MACDs_12_26_9`). Pick the components you need and name them yourself: the exo column names are the ones you will type in the expression, so short stable names survive a parameter change.
+
+```python
+macd = ta.macd(df['close'], fast=12, slow=26, signal=9)
+
+signals = pd.DataFrame(
+    {
+        'timestamp': df['timestamp'],
+        'macd': macd['MACD_12_26_9'],
+        'macd_signal': macd['MACDs_12_26_9'],
+    }
+).dropna()
+
+position = when(exo('pandas_ta', 'macd') > exo('pandas_ta', 'macd_signal'), lit(1.0), lit(0.0))
+```
+
+### Pattern C: OHLCV-Dependent Indicators (ATR)
+
+Indicators that need more than the close take the other Series as usual. Nothing changes on the engine side: the result is one more exo column.
+
+```python
+signals['atr'] = ta.atr(df['high'], df['low'], df['close'], length=14)
+```
+
+Engine expressions compose on top of an exo column like any other series, so a volatility filter can be written against it directly:
+
+```python
+wide = exo('pandas_ta', 'atr') > exo('pandas_ta', 'atr').rolling_mean(50)
+position = when(trend, when(wide, lit(0.5), lit(1.0)), lit(0.0))
+```
+
+---
+
+## 3. Things That Bite
+
+- **Declare the series in the config.** `BacktestConfig(exo_data=['pandas_ta'])` is what makes the columns resolvable; without it the expression refers to a column the engine never loaded.
+- **Drop the warmup rows before registering.** A leading `NaN` block is forward-filled from nothing, so the first bars would compare against missing values. `dropna()` on the exo frame, and `warmup_bars` at least as long as the longest indicator window.
+- **Name the columns in the exo frame, not in the expression.** `exo('pandas_ta', 'macd')` reads better than the parameter-encoded `MACD_12_26_9`, and it does not change when you retune the indicator.
+- **A store keeps its metadata database open.** Removing a temporary store directory inside a `TemporaryDirectory` context manager fails on Windows while the process is alive; delete it with errors ignored, or keep the store on disk between runs.
+
+---
+
+## 4. Runnable Example
+
+`examples/manifoldbt_strategy.py` runs the same SMA crossover as the backtesting.py and backtrader examples, on the same synthetic series, and prints total return, Sharpe, max drawdown and the round-trip count.
+
+```bash
+pip install manifoldbt
+python examples/manifoldbt_strategy.py
+```

--- a/examples/manifoldbt_strategy.py
+++ b/examples/manifoldbt_strategy.py
@@ -1,0 +1,107 @@
+import shutil
+import tempfile
+from pathlib import Path
+
+import manifoldbt as mbt
+import numpy as np
+import pandas as pd
+import pandas_ta_classic as ta
+from manifoldbt.expr import col, exo, lit, when
+from manifoldbt.helpers import Interval, Slippage, time_range
+
+_ = ta.__name__  # registers df.ta accessor
+
+
+def synthetic_ohlcv(n: int = 500, seed: int = 42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    close = 100 * np.cumprod(1 + rng.normal(0, 0.01, n))
+    high = close * (1 + np.abs(rng.normal(0, 0.005, n)))
+    low = close * (1 - np.abs(rng.normal(0, 0.005, n)))
+    open_ = np.clip(close * (1 + rng.normal(0, 0.002, n)), low, high)
+    return pd.DataFrame(
+        {
+            'timestamp': pd.date_range('2020-01-01', periods=n, freq='D', tz='UTC'),
+            'open': open_,
+            'high': high,
+            'low': low,
+            'close': close,
+            'volume': rng.integers(1_000_000, 10_000_000, n).astype(float),
+        }
+    )
+
+
+def run(fast_length: int = 10, slow_length: int = 20) -> None:
+    df = synthetic_ohlcv()
+
+    # Precompute indicators - pandas-ta-classic works over the full Series here,
+    # so every value is available before the engine starts. manifoldbt evaluates
+    # expressions over whole columns rather than bar by bar, so the indicators are
+    # handed over as a data series instead of being recomputed inside a callback.
+    signals = pd.DataFrame(
+        {
+            'timestamp': df['timestamp'],
+            'sma_fast': ta.sma(df['close'], length=fast_length),
+            'sma_slow': ta.sma(df['close'], length=slow_length),
+        }
+    ).dropna()
+
+    # The store keeps its metadata database open for the lifetime of the process,
+    # so the directory is removed with errors ignored rather than by a context
+    # manager, which would fail on Windows.
+    tmp = tempfile.mkdtemp()
+    try:
+        root = Path(tmp)
+        store = mbt.import_dataframe(
+            df,
+            symbol='SYNTH',
+            symbol_id=1,
+            interval='1d',
+            data_root=str(root / 'data'),
+            metadata_db=str(root / 'metadata.sqlite'),
+            exchange='dataframe',
+            asset_class='equity',
+        )
+        # Exogenous series: the bridge that carries pandas-ta-classic output into
+        # the engine. Referenced in expressions as exo('pandas_ta', '<column>').
+        mbt.register_exo('pandas_ta', signals, store=store)
+
+        position = when(
+            exo('pandas_ta', 'sma_fast') > exo('pandas_ta', 'sma_slow'),
+            lit(1.0),
+            lit(0.0),
+        )
+        strategy = mbt.Strategy.create('sma-crossover').signal('pos', position).size(col('pos'))
+
+        start, end = time_range('2020-01-01', '2021-06-01')
+        config = mbt.BacktestConfig(
+            universe=[1],
+            time_range_start=start,
+            time_range_end=end,
+            bar_interval=Interval.hours(24),
+            initial_capital=10_000.0,
+            warmup_bars=slow_length,
+            exo_data=['pandas_ta'],
+            execution=mbt.ExecutionConfig(
+                signal_delay=1,
+                execution_price='AtClose',
+                allow_short=False,
+                position_sizing_mode='FractionOfEquity',
+            ),
+            fees=mbt.FeeConfig(taker_fee_bps=20.0, maker_fee_bps=20.0),
+            slippage=Slippage.none(),
+        )
+
+        result = mbt.run(strategy, config, store)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    m = result.metrics
+    print(f"\n--- SMA Crossover ({fast_length}/{slow_length}) ---")
+    print(f"Total return:  {m['total_return'] * 100:.2f}%")
+    print(f"Sharpe ratio:  {m['sharpe']:.2f}")
+    print(f"Max drawdown:  {abs(m['max_drawdown']) * 100:.2f}%")
+    print(f"Round trips:   {m['trade_stats']['round_trips']}")
+
+
+if __name__ == '__main__':
+    run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,8 @@ data = [
 backtest = [
     "backtesting",
     "vectorbt",
-    "backtrader"
+    "backtrader",
+    "manifoldbt"
 ]
 
 # Back-compat alias for the previous combined extra


### PR DESCRIPTION
## What this adds

A fourth backtesting integration, following the shape already established by `backtesting_py_strategy.py` and `backtrader_strategy.py`:

- `examples/manifoldbt_strategy.py` - runnable SMA crossover, same synthetic series and same printed metrics as the backtrader example
- `docs/tutorials/manifoldbt.md` - integration guide
- `docs/tutorials.md`, `README.md` - tutorial listed alongside the existing three
- `pyproject.toml` - `manifoldbt` added to the `backtest` extra
- `CHANGELOG.md` - `[Unreleased]` entry

## Why the pattern differs from the existing three

[manifoldbt](https://github.com/manifoldbt/manifoldbt) evaluates strategies as expressions over whole columns rather than through a per-bar `next()` callback, and it reads bars from a store it owns. There is no hook where an indicator could be computed, and an extra column on the input DataFrame is not visible to expressions. So the bridge is neither backtesting.py's `self.I()` nor backtrader's extra `lines`: pandas-ta-classic output is registered as an *exogenous series*, which the engine ASOF-joins onto its bars.

```python
signals = pd.DataFrame({'timestamp': df['timestamp'], 'sma_fast': ta.sma(df['close'], 10)}).dropna()
mbt.register_exo('pandas_ta', signals, store=store)
position = when(exo('pandas_ta', 'sma_fast') > exo('pandas_ta', 'sma_slow'), lit(1.0), lit(0.0))
```

The guide covers single-output, multi-output (MACD) and OHLCV-dependent (ATR) indicators.

## What was verified

- Every snippet in the guide was executed before being written down, including the MACD and ATR variants. Nothing in it is written from memory.
- The example is deterministic: repeated runs print `-24.68%` total return, Sharpe `-1.59`, 14 round trips on `seed=42`. (A moving-average crossover on a random walk paying 20 bps a fill loses money, which is the expected outcome here, not a broken integration.)
- `black --check` and `ruff check --select E9,F63,F7,F82` pass on the new example.
- No library code is touched, so nothing in `pandas_ta_classic/` changes behaviour.
- `pytest tests/ -q` on this branch: 1399 passed, 60 skipped, 814 subtests passed, 2 failed. The two failures are `test_oracle_tulipy.py::test_stochrsi` and `::test_trima`, and they reproduce identically on `33c855e` with this branch not applied, so they are the numpy float drift the CHANGELOG already describes for the frozen oracle, not something this PR introduces.

## Three things worth your judgement

1. **Placement.** I appended it as Tutorial 10 rather than inserting it as Tutorial 7 next to the other integrations, because inserting would renumber Tutorials 7-9 and change their `(tutorial-N-...)=` anchors, breaking existing deep links. Happy to move it if you prefer the grouping over the anchor stability.

2. **The `backtest` extra.** I added `manifoldbt` to it for consistency with the other three, but the extra's comment says it exists to isolate platform-fragile packages, so this is your call. For what it is worth it ships `cp39-abi3` wheels covering Python 3.9 through 3.14 across macOS (x86_64/arm64), manylinux, musllinux and Windows, with no compiler needed. Say the word and I will drop it from the extra and document `pip install manifoldbt` in the guide only.

3. **Licence, stated up front.** manifoldbt is Apache 2.0 plus Commons Clause, so it is source-available rather than OSI open source, and it has paid tiers. The example is one backtest at daily resolution; larger fan-outs and walk-forward are licensed features and are left out of it. The guide itself states no pricing, so nothing in your tree goes stale if the tiers move. If a source-available dependency in the `backtest` extra is not something you want, point 2 is the way out and the guide still stands on its own.

**Disclosure:** I am the author of manifoldbt. I am proposing this as the missing fourth integration for a library I use with it, not as a promotional entry, and I would rather you know that before reviewing than find out afterwards.
